### PR TITLE
fix: enforce partition node structural rules in rendering and validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "layercake-tool",
-      "version": "0.3.3",
+      "version": "0.3.7",
       "license": "MIT OR Apache-2.0"
     }
   }


### PR DESCRIPTION
Partition nodes (is_partition=true) must only act as containers and cannot have edges connecting to them. This is a core layercake structural rule.

Changes:
- Updated mermaid_render_tree helper to check is_partition flag
  * Partition nodes with children render as subgraphs only
  * Regular nodes always render as nodes, even with children
- Updated dot_render_tree helper with same logic for clusters
- Updated puml_render_tree helper for PlantUML containers
- Added validation in verify_graph_integrity() to detect edges connecting to partition nodes and report as errors
- Updated test to expect validation errors for partition edges

Regular nodes (is_partition=false) with children now render correctly as both node elements and containers for their children, allowing edges to connect to them.