### PR TITLE
Fix FilterNode querying dropped legacy graph_nodes table

### DIFF
--- a/layercake-core/src/plan_dag/filter.rs
+++ b/layercake-core/src/plan_dag/filter.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result as AnyResult};
-use sea_orm::{ConnectionTrait, DatabaseConnection, FromQueryResult, Statement};
+use sea_orm::DatabaseConnection;
 use serde::{de, Deserialize, Serialize};
 use serde_json::json;
 use serde_json::Value as JsonValue;
@@ -171,19 +171,34 @@ mod query_filter_executor {
         let mut selected_edges = HashSet::new();
         let mut selected_layers = HashSet::new();
 
+        // Evaluate the rule group against the in-memory graph. The graph is
+        // already fully loaded here, so there is no need (and, since the legacy
+        // graph_nodes/graph_edges/graph_layers tables were dropped, no ability)
+        // to re-query the database. `_context` is retained for API stability.
+        let _ = context;
+
         if targets.contains(&QueryFilterTarget::Nodes) {
-            let nodes = query_nodes(context.db, context.graph_id, &rule_group).await?;
-            selected_nodes.extend(nodes);
+            for node in &graph.nodes {
+                if eval_rule_group(&rule_group, &node_field_value(node))? {
+                    selected_nodes.insert(node.id.clone());
+                }
+            }
         }
 
         if targets.contains(&QueryFilterTarget::Edges) {
-            let edges = query_edges(context.db, context.graph_id, &rule_group).await?;
-            selected_edges.extend(edges);
+            for edge in &graph.edges {
+                if eval_rule_group(&rule_group, &edge_field_value(edge))? {
+                    selected_edges.insert(edge.id.clone());
+                }
+            }
         }
 
         if targets.contains(&QueryFilterTarget::Layers) {
-            let layers = query_layers(context.db, context.graph_id, &rule_group).await?;
-            selected_layers.extend(layers);
+            for layer in &graph.layers {
+                if eval_rule_group(&rule_group, &layer_field_value(layer))? {
+                    selected_layers.insert(layer.id.clone());
+                }
+            }
         }
 
         let should_include = matches!(config.mode, QueryFilterMode::Include);
@@ -268,129 +283,125 @@ mod query_filter_executor {
         Ok(())
     }
 
-    async fn query_nodes(
-        db: &DatabaseConnection,
-        graph_id: i32,
-        rule_group: &QueryRuleGroup,
-    ) -> AnyResult<HashSet<String>> {
-        let sql = build_query_sql("graph_nodes", graph_id, rule_group)?;
-        execute_query(db, &sql)
-            .await
-            .context("Failed to query nodes")
+    /// Resolve a filter `field` to a string value for a node. Known columns map
+    /// to struct fields; anything else is looked up in the `attributes` JSON.
+    fn node_field_value(node: &crate::graph::Node) -> impl Fn(&str) -> Option<String> + '_ {
+        move |field: &str| match field {
+            "id" | "external_id" => Some(node.id.clone()),
+            "label" => Some(node.label.clone()),
+            "layer" => Some(node.layer.clone()),
+            "weight" => Some(node.weight.to_string()),
+            "comment" => node.comment.clone(),
+            "belongs_to" | "belongsTo" => node.belongs_to.clone(),
+            "is_partition" | "isPartition" => Some(node.is_partition.to_string()),
+            "dataset" => node.dataset.map(|d| d.to_string()),
+            other => attribute_value(node.attributes.as_ref(), other),
+        }
     }
 
-    async fn query_edges(
-        db: &DatabaseConnection,
-        graph_id: i32,
-        rule_group: &QueryRuleGroup,
-    ) -> AnyResult<HashSet<String>> {
-        let sql = build_query_sql("graph_edges", graph_id, rule_group)?;
-        execute_query(db, &sql)
-            .await
-            .context("Failed to query edges")
+    fn edge_field_value(edge: &crate::graph::Edge) -> impl Fn(&str) -> Option<String> + '_ {
+        move |field: &str| match field {
+            "id" | "external_id" => Some(edge.id.clone()),
+            "source" => Some(edge.source.clone()),
+            "target" => Some(edge.target.clone()),
+            "label" => Some(edge.label.clone()),
+            "layer" => Some(edge.layer.clone()),
+            "weight" => Some(edge.weight.to_string()),
+            "comment" => edge.comment.clone(),
+            "dataset" => edge.dataset.map(|d| d.to_string()),
+            other => attribute_value(edge.attributes.as_ref(), other),
+        }
     }
 
-    async fn query_layers(
-        db: &DatabaseConnection,
-        graph_id: i32,
-        rule_group: &QueryRuleGroup,
-    ) -> AnyResult<HashSet<String>> {
-        let sql = build_query_sql("graph_layers", graph_id, rule_group)?;
-        execute_query(db, &sql)
-            .await
-            .context("Failed to query layers")
+    fn layer_field_value(layer: &crate::graph::Layer) -> impl Fn(&str) -> Option<String> + '_ {
+        move |field: &str| match field {
+            "id" => Some(layer.id.clone()),
+            "label" => Some(layer.label.clone()),
+            "alias" => layer.alias.clone(),
+            "dataset" => layer.dataset.map(|d| d.to_string()),
+            other => attribute_value(layer.attributes.as_ref(), other),
+        }
     }
 
-    async fn execute_query(db: &DatabaseConnection, sql: &str) -> AnyResult<HashSet<String>> {
-        #[derive(FromQueryResult)]
-        struct ResultRow {
-            id: String,
+    /// Look up a field in an optional `attributes` JSON object, returning its
+    /// value as a string (strings unquoted, numbers/bools stringified).
+    fn attribute_value(attributes: Option<&JsonValue>, field: &str) -> Option<String> {
+        let value = attributes?.get(field)?;
+        match value {
+            JsonValue::String(s) => Some(s.clone()),
+            JsonValue::Null => None,
+            other => Some(other.to_string()),
+        }
+    }
+
+    /// Evaluate a rule group against a single record's field resolver.
+    fn eval_rule_group(
+        rule_group: &QueryRuleGroup,
+        get_field: &impl Fn(&str) -> Option<String>,
+    ) -> AnyResult<bool> {
+        let is_and = !rule_group.combinator.eq_ignore_ascii_case("or");
+
+        // An empty rule group matches everything (parity with the previous "1=1").
+        if rule_group.rules.is_empty() {
+            return Ok(true);
         }
 
-        let statement = Statement::from_string(db.get_database_backend(), sql.to_string());
-        let rows: Vec<ResultRow> = ResultRow::find_by_statement(statement)
-            .all(db)
-            .await
-            .context("Failed to execute query")?;
-
-        Ok(rows.into_iter().map(|row| row.id).collect())
-    }
-
-    fn build_query_sql(
-        table: &str,
-        graph_id: i32,
-        rule_group: &QueryRuleGroup,
-    ) -> AnyResult<String> {
-        let rule_sql = build_rule_group_sql(rule_group)?;
-        Ok(format!(
-            "SELECT id FROM {} WHERE graph_id = {} AND {}",
-            table, graph_id, rule_sql
-        ))
-    }
-
-    fn build_rule_group_sql(rule_group: &QueryRuleGroup) -> AnyResult<String> {
-        let mut clauses = Vec::new();
+        let mut result = is_and;
         for rule in &rule_group.rules {
-            match rule {
-                QueryRule::Group(group) => {
-                    let group_sql = build_rule_group_sql(group)?;
-                    clauses.push(format!("({})", group_sql));
+            let matched = match rule {
+                QueryRule::Group(group) => eval_rule_group(group, get_field)?,
+                QueryRule::Rule(rule) => eval_rule(rule, get_field)?,
+            };
+            if is_and {
+                result = result && matched;
+                if !result {
+                    break;
                 }
-                QueryRule::Rule(rule) => {
-                    let clause = build_rule_clause(rule)?;
-                    clauses.push(clause);
+            } else {
+                result = result || matched;
+                if result {
+                    break;
                 }
             }
         }
-
-        let joiner = match rule_group.combinator.as_str() {
-            "and" => " AND ",
-            "or" => " OR ",
-            _ => " AND ",
-        };
-
-        if clauses.is_empty() {
-            Ok("1=1".to_string())
-        } else {
-            Ok(clauses.join(joiner))
-        }
+        Ok(result)
     }
 
-    fn build_rule_clause(rule: &QueryRuleConfig) -> AnyResult<String> {
-        let field = &rule.field;
-        let operator = rule.operator.as_str();
+    fn eval_rule(
+        rule: &QueryRuleConfig,
+        get_field: &impl Fn(&str) -> Option<String>,
+    ) -> AnyResult<bool> {
+        let field_value = get_field(&rule.field);
         let value = rule.value.as_deref().unwrap_or("");
         let comparator = rule.comparator.as_deref().unwrap_or("=");
 
-        let clause = match operator {
-            "isEmpty" => format!("({} IS NULL OR {} = '')", field, field),
-            "isNotEmpty" => format!("({} IS NOT NULL AND {} <> '')", field, field),
-            "contains" => format!("{} LIKE '%{}%'", field, value.replace('\'', "''")),
-            "notContains" => format!("{} NOT LIKE '%{}%'", field, value.replace('\'', "''")),
-            "equals" => format!("{} {} '{}'", field, comparator, value.replace('\'', "''")),
-            "notEquals" => format!("{} {} '{}'", field, comparator, value.replace('\'', "''")),
-            "startsWith" => format!("{} LIKE '{}%'", field, value.replace('\'', "''")),
-            "endsWith" => format!("{} LIKE '%{}'", field, value.replace('\'', "''")),
+        let as_str = field_value.as_deref();
+        let matched = match rule.operator.as_str() {
+            "isEmpty" => as_str.map(|s| s.is_empty()).unwrap_or(true),
+            "isNotEmpty" => as_str.map(|s| !s.is_empty()).unwrap_or(false),
+            "isNull" => field_value.is_none(),
+            "isNotNull" => field_value.is_some(),
+            "contains" => as_str.map(|s| s.contains(value)).unwrap_or(false),
+            "notContains" => as_str.map(|s| !s.contains(value)).unwrap_or(true),
+            "startsWith" => as_str.map(|s| s.starts_with(value)).unwrap_or(false),
+            "endsWith" => as_str.map(|s| s.ends_with(value)).unwrap_or(false),
+            "equals" => match comparator {
+                "<>" | "!=" => as_str != Some(value),
+                _ => as_str == Some(value),
+            },
+            "notEquals" => as_str != Some(value),
             "in" => {
-                let items: Vec<String> = value
-                    .split(',')
-                    .map(|item| format!("'{}'", item.trim().replace('\'', "''")))
-                    .collect();
-                format!("{} IN ({})", field, items.join(", "))
+                let set: HashSet<&str> = value.split(',').map(|s| s.trim()).collect();
+                as_str.map(|s| set.contains(s)).unwrap_or(false)
             }
             "notIn" => {
-                let items: Vec<String> = value
-                    .split(',')
-                    .map(|item| format!("'{}'", item.trim().replace('\'', "''")))
-                    .collect();
-                format!("{} NOT IN ({})", field, items.join(", "))
+                let set: HashSet<&str> = value.split(',').map(|s| s.trim()).collect();
+                as_str.map(|s| !set.contains(s)).unwrap_or(true)
             }
-            "isNull" => format!("{} IS NULL", field),
-            "isNotNull" => format!("{} IS NOT NULL", field),
-            "greaterThan" => format!("{} > {}", field, value),
-            "lessThan" => format!("{} < {}", field, value),
-            "greaterThanOrEqual" => format!("{} >= {}", field, value),
-            "lessThanOrEqual" => format!("{} <= {}", field, value),
+            "greaterThan" => numeric_cmp(as_str, value, |a, b| a > b),
+            "lessThan" => numeric_cmp(as_str, value, |a, b| a < b),
+            "greaterThanOrEqual" => numeric_cmp(as_str, value, |a, b| a >= b),
+            "lessThanOrEqual" => numeric_cmp(as_str, value, |a, b| a <= b),
             "between" => {
                 let parts: Vec<&str> = value.split(',').collect();
                 if parts.len() != 2 {
@@ -398,15 +409,31 @@ mod query_filter_executor {
                         "Between operator requires two values separated by comma"
                     ));
                 }
-                format!("{} BETWEEN {} AND {}", field, parts[0], parts[1])
+                let lo = parts[0].trim().parse::<f64>().ok();
+                let hi = parts[1].trim().parse::<f64>().ok();
+                match (as_str.and_then(|s| s.trim().parse::<f64>().ok()), lo, hi) {
+                    (Some(v), Some(lo), Some(hi)) => v >= lo && v <= hi,
+                    _ => false,
+                }
             }
-            _ => {
-                warn!("Unsupported operator: {}", operator);
-                "1=1".to_string()
+            other => {
+                warn!("Unsupported filter operator: {}", other);
+                true
             }
         };
+        Ok(matched)
+    }
 
-        Ok(clause)
+    /// Compare a field value and a target value numerically; if either is not a
+    /// number, no match (mirrors SQL comparison against non-numeric text).
+    fn numeric_cmp(field: Option<&str>, value: &str, op: impl Fn(f64, f64) -> bool) -> bool {
+        match (
+            field.and_then(|s| s.trim().parse::<f64>().ok()),
+            value.trim().parse::<f64>().ok(),
+        ) {
+            (Some(a), Some(b)) => op(a, b),
+            _ => false,
+        }
     }
 
     #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/layercake-core/tests/filter_node_test.rs
+++ b/layercake-core/tests/filter_node_test.rs
@@ -1,0 +1,221 @@
+//! Tests for FilterNode query evaluation.
+//!
+//! The filter used to build raw SQL against the legacy `graph_nodes` /
+//! `graph_edges` / `graph_layers` tables (dropped by m20251215), so any plan
+//! with a filter node failed with "no such table: graph_nodes". It now
+//! evaluates rules against the in-memory graph. These tests exercise that
+//! evaluation directly, independent of the DAG executor.
+
+use layercake as layercake_core;
+use layercake_core::graph::{Edge, Graph, Layer, Node};
+use layercake_core::plan_dag::{FilterEvaluationContext, FilterNodeConfig};
+use sea_orm::{Database, DatabaseConnection};
+use serde_json::json;
+
+async fn any_db() -> DatabaseConnection {
+    // The filter no longer touches the DB, but the context still carries a
+    // connection for API stability.
+    Database::connect("sqlite::memory:").await.unwrap()
+}
+
+fn node(id: &str, label: &str, layer: &str, weight: i32) -> Node {
+    Node {
+        id: id.to_string(),
+        label: label.to_string(),
+        layer: layer.to_string(),
+        is_partition: false,
+        belongs_to: None,
+        weight,
+        comment: None,
+        dataset: None,
+        attributes: None,
+    }
+}
+
+fn edge(id: &str, source: &str, target: &str) -> Edge {
+    Edge {
+        id: id.to_string(),
+        source: source.to_string(),
+        target: target.to_string(),
+        label: String::new(),
+        layer: "L1".to_string(),
+        weight: 1,
+        comment: None,
+        dataset: None,
+        attributes: None,
+    }
+}
+
+fn sample_graph() -> Graph {
+    Graph {
+        name: "g".into(),
+        nodes: vec![
+            node("a", "Alpha", "L1", 5),
+            node("b", "Beta", "L1", 1),
+            node("c", "Gamma", "L2", 9),
+        ],
+        edges: vec![edge("e1", "a", "b"), edge("e2", "b", "c")],
+        layers: vec![
+            Layer {
+                id: "L1".into(),
+                label: "Layer 1".into(),
+                background_color: "#fff".into(),
+                text_color: "#000".into(),
+                border_color: "#000".into(),
+                alias: None,
+                dataset: None,
+                attributes: None,
+            },
+            Layer {
+                id: "L2".into(),
+                label: "Layer 2".into(),
+                background_color: "#fff".into(),
+                text_color: "#000".into(),
+                border_color: "#000".into(),
+                alias: None,
+                dataset: None,
+                attributes: None,
+            },
+        ],
+        annotations: None,
+    }
+}
+
+async fn apply(graph: &mut Graph, config_json: serde_json::Value) {
+    let config: FilterNodeConfig = serde_json::from_str(&config_json.to_string()).unwrap();
+    let db = any_db().await;
+    config
+        .apply_filters(
+            graph,
+            &FilterEvaluationContext {
+                db: &db,
+                graph_id: 1,
+            },
+        )
+        .await
+        .expect("filter should apply without touching dropped tables");
+}
+
+#[tokio::test]
+async fn empty_rule_group_keeps_all_nodes() {
+    let mut graph = sample_graph();
+    apply(
+        &mut graph,
+        json!({"query": {
+            "targets": ["nodes"], "mode": "include",
+            "linkPruningMode": "retainEdges",
+            "ruleGroup": {"combinator": "and", "rules": []},
+            "fieldMetadataVersion": "v1"
+        }}),
+    )
+    .await;
+    assert_eq!(graph.nodes.len(), 3, "no rules => keep everything");
+}
+
+#[tokio::test]
+async fn include_filters_nodes_by_layer_equals() {
+    let mut graph = sample_graph();
+    apply(
+        &mut graph,
+        json!({"query": {
+            "targets": ["nodes"], "mode": "include",
+            "linkPruningMode": "autoDropDanglingEdges",
+            "ruleGroup": {"combinator": "and", "rules": [
+                {"type": "rule", "field": "layer", "operator": "equals", "value": "L1"}
+            ]},
+            "fieldMetadataVersion": "v1"
+        }}),
+    )
+    .await;
+
+    let ids: Vec<&str> = graph.nodes.iter().map(|n| n.id.as_str()).collect();
+    assert_eq!(ids, vec!["a", "b"], "only L1 nodes kept");
+    // Edge c->... referencing the dropped node c is auto-pruned.
+    assert_eq!(graph.edges.len(), 1);
+    assert_eq!(graph.edges[0].id, "e1");
+}
+
+#[tokio::test]
+async fn exclude_mode_removes_matching_nodes() {
+    let mut graph = sample_graph();
+    apply(
+        &mut graph,
+        json!({"query": {
+            "targets": ["nodes"], "mode": "exclude",
+            "linkPruningMode": "retainEdges",
+            "ruleGroup": {"combinator": "and", "rules": [
+                {"type": "rule", "field": "layer", "operator": "equals", "value": "L2"}
+            ]},
+            "fieldMetadataVersion": "v1"
+        }}),
+    )
+    .await;
+    let ids: Vec<&str> = graph.nodes.iter().map(|n| n.id.as_str()).collect();
+    assert_eq!(ids, vec!["a", "b"], "L2 node excluded");
+}
+
+#[tokio::test]
+async fn numeric_greater_than_on_weight() {
+    let mut graph = sample_graph();
+    apply(
+        &mut graph,
+        json!({"query": {
+            "targets": ["nodes"], "mode": "include",
+            "linkPruningMode": "retainEdges",
+            "ruleGroup": {"combinator": "and", "rules": [
+                {"type": "rule", "field": "weight", "operator": "greaterThan", "value": "3"}
+            ]},
+            "fieldMetadataVersion": "v1"
+        }}),
+    )
+    .await;
+    let mut ids: Vec<&str> = graph.nodes.iter().map(|n| n.id.as_str()).collect();
+    ids.sort();
+    assert_eq!(ids, vec!["a", "c"], "weight > 3 keeps a(5) and c(9)");
+}
+
+#[tokio::test]
+async fn or_combinator_and_contains() {
+    let mut graph = sample_graph();
+    apply(
+        &mut graph,
+        json!({"query": {
+            "targets": ["nodes"], "mode": "include",
+            "linkPruningMode": "retainEdges",
+            "ruleGroup": {"combinator": "or", "rules": [
+                {"type": "rule", "field": "label", "operator": "contains", "value": "Alph"},
+                {"type": "rule", "field": "label", "operator": "equals", "value": "Gamma"}
+            ]},
+            "fieldMetadataVersion": "v1"
+        }}),
+    )
+    .await;
+    let mut ids: Vec<&str> = graph.nodes.iter().map(|n| n.id.as_str()).collect();
+    ids.sort();
+    assert_eq!(ids, vec!["a", "c"]);
+}
+
+#[tokio::test]
+async fn filter_by_custom_attribute() {
+    let mut graph = sample_graph();
+    graph.nodes[0].attributes = Some(json!({"severity": "high"}));
+    graph.nodes[2].attributes = Some(json!({"severity": "low"}));
+    apply(
+        &mut graph,
+        json!({"query": {
+            "targets": ["nodes"], "mode": "include",
+            "linkPruningMode": "retainEdges",
+            "ruleGroup": {"combinator": "and", "rules": [
+                {"type": "rule", "field": "severity", "operator": "equals", "value": "high"}
+            ]},
+            "fieldMetadataVersion": "v1"
+        }}),
+    )
+    .await;
+    let ids: Vec<&str> = graph.nodes.iter().map(|n| n.id.as_str()).collect();
+    assert_eq!(
+        ids,
+        vec!["a"],
+        "attribute-based filtering works via the JSON bag"
+    );
+}

--- a/layercake-core/tests/graph_data_pipeline_e2e.rs
+++ b/layercake-core/tests/graph_data_pipeline_e2e.rs
@@ -30,6 +30,25 @@ async fn seed_project_and_palette(db: &DatabaseConnection) -> i32 {
     };
     project.insert(db).await.unwrap();
 
+    // Plan (id 1) so plan_dag_nodes referencing plan_id = 1 satisfy their FK.
+    use layercake_core::database::entities::plans;
+    plans::ActiveModel {
+        id: Set(1),
+        project_id: Set(1),
+        name: Set("Pipeline Plan".into()),
+        description: Set(None),
+        tags: Set("[]".into()),
+        yaml_content: Set("{}".into()),
+        dependencies: Set(None),
+        status: Set("draft".to_string()),
+        version: Set(1),
+        created_at: Set(Utc::now()),
+        updated_at: Set(Utc::now()),
+    }
+    .insert(db)
+    .await
+    .unwrap();
+
     // Palette layer
     let layer = project_layers::ActiveModel {
         id: sea_orm::ActiveValue::NotSet,
@@ -135,12 +154,14 @@ async fn create_graph_data_dataset(
     dataset
 }
 
-// FIXME (pre-existing PRODUCT BUG): FilterNode execution queries the legacy
-// `graph_nodes` table, which was dropped by m20251215. Under FK/strict schema
-// this fails with "no such table: graph_nodes". The filter path needs porting
-// to graph_data (like the rest of the pipeline). Predates Horizon 1; ignored
-// here to keep the build green, but this is a real bug to fix, not just a test.
-#[ignore = "pre-existing product bug: FilterNode queries dropped legacy graph_nodes table - see FIXME"]
+// The FilterNode legacy-table bug this test used to hit is fixed (see
+// filter_node_test.rs for direct coverage). It now blocks on a *separate*
+// pre-existing bug: the GraphNode executor arm resolves inputs only from DAG
+// edges and ignores the `graphDataIds` config, so source GraphNodes build empty
+// graphs and node_count propagates as 0. Ignored until that GraphNode-input
+// resolution is fixed. (Test setup was also corrected to seed the plan + DAG
+// node rows so execution reaches the filter/projection nodes.)
+#[ignore = "pre-existing: GraphNode arm ignores graphDataIds config -> empty source graphs; FilterNode part is fixed and covered by filter_node_test"]
 #[tokio::test]
 async fn graph_data_pipeline_end_to_end() {
     let db = setup_db().await;
@@ -251,6 +272,15 @@ async fn graph_data_pipeline_end_to_end() {
         ("transform-1".to_string(), "filter-1".to_string()),
         ("filter-1".to_string(), "projection-1".to_string()),
     ];
+
+    // Persist the plan DAG nodes so nodes that write back to their own config
+    // (e.g. ProjectionNode storing the created projectionId) have a real row to
+    // update. execute_dag takes the node models by value but expects them to
+    // exist in the database.
+    for node in &nodes {
+        let active: plan_dag_nodes::ActiveModel = node.clone().into();
+        active.insert(&db).await.unwrap();
+    }
 
     let executor = DagExecutor::new(db.clone());
     executor


### PR DESCRIPTION
## FilterNode: fix "no such table: graph_nodes"

Fixes the product bug surfaced during Horizon 1: **any plan containing a FilterNode failed at execution** with `no such table: graph_nodes`. The filter built raw SQL against the legacy `graph_nodes` / `graph_edges` / `graph_layers` tables, which were dropped by `m20251215`.

### Fix
The graph is already fully in memory when the filter runs, so re-querying the DB was never necessary. Rewrote the node/edge/layer query functions to **evaluate the rule group against the in-memory `Graph`**:
- Fields resolve to struct fields (`label`, `layer`, `weight`, `belongs_to`, …) or the `attributes` JSON bag.
- All operators evaluated in Rust: `equals/notEquals/contains/startsWith/in/isNull/isEmpty/greaterThan/lessThan/between/…`.
- Also removes a **SQL-injection surface** — field names were previously interpolated straight into raw SQL.

### Tests
- New `filter_node_test.rs` (6 tests): include/exclude modes, layer/label/weight/attribute fields, `and`/`or` combinators, and edge pruning.
- `graph_data_pipeline_e2e` now flows past the filter cleanly. Its setup was corrected (seed the plan + DAG node rows); it stays `#[ignore]` on a **separate pre-existing bug** — the `GraphNode` executor arm ignores the `graphDataIds` config, so source GraphNodes build empty graphs. Flagged for a follow-up.

Core: 249 pass / 0 fail / 30 ignored · server 26 pass · clippy clean.

### Note
Stacked on top of #58 (Horizon 1). Base is `feature/horizon-1-stabilise`; merge after #58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
