### PR TITLE
Fix empty download filename for artefact exports

### DIFF
--- a/frontend/src/components/editors/PlanVisualEditor/nodes/GraphArtefactNode.tsx
+++ b/frontend/src/components/editors/PlanVisualEditor/nodes/GraphArtefactNode.tsx
@@ -22,6 +22,7 @@ import { resolveNodeHandlers } from './nodeHandlers'
 import { showErrorNotification, showSuccessNotification } from '../../../../utils/notifications'
 import { MermaidPreviewDialog, DotPreviewDialog } from '../../../visualization'
 import { usePlanVisualEditorContext } from '../context'
+import { fallbackExportFilename } from '@/utils/exportFilename'
 
 type ArtefactConfig = GraphArtefactNodeConfig | TreeArtefactNodeConfig
 
@@ -166,12 +167,17 @@ const ArtefactNodeBase = memo((props: ArtefactNodeProps) => {
           const url = window.URL.createObjectURL(blob)
           const link = document.createElement('a')
           link.href = url
-          link.download = result.filename
+          // The backend returns an empty filename when the artefact node has no
+          // outputPath configured; fall back to a sensible name so the browser
+          // doesn't download a nameless file.
+          const downloadName =
+            result.filename || fallbackExportFilename(config.renderTarget, data.metadata?.label, result.mimeType)
+          link.download = downloadName
           document.body.appendChild(link)
           link.click()
           document.body.removeChild(link)
           window.URL.revokeObjectURL(url)
-          showSuccessNotification('Download Complete', result.filename)
+          showSuccessNotification('Download Complete', downloadName)
         } catch (error) {
           console.error('Failed to decode and download:', error)
           showErrorNotification('Download Failed', 'Failed to decode export content')

--- a/frontend/src/components/editors/PlanVisualEditor/nodes/SequenceArtefactNode.tsx
+++ b/frontend/src/components/editors/PlanVisualEditor/nodes/SequenceArtefactNode.tsx
@@ -21,6 +21,7 @@ import { BaseNode } from './BaseNode'
 import { resolveNodeHandlers } from './nodeHandlers'
 import { showErrorNotification, showSuccessNotification } from '../../../../utils/notifications'
 import { MermaidPreviewDialog } from '../../../visualization'
+import { fallbackExportFilename } from '@/utils/exportFilename'
 
 interface ExtendedNodeProps extends NodeProps {
   onEdit?: (nodeId: string) => void
@@ -65,12 +66,15 @@ export const SequenceArtefactNode = memo((props: ExtendedNodeProps) => {
           const url = window.URL.createObjectURL(blob)
           const link = document.createElement('a')
           link.href = url
-          link.download = result.filename
+          // Empty filename (no configured outputPath) → fall back to a name.
+          const downloadName =
+            result.filename || fallbackExportFilename(config.renderTarget, data.metadata?.label, result.mimeType)
+          link.download = downloadName
           document.body.appendChild(link)
           link.click()
           document.body.removeChild(link)
           window.URL.revokeObjectURL(url)
-          showSuccessNotification('Download Complete', result.filename)
+          showSuccessNotification('Download Complete', downloadName)
         } catch (error) {
           console.error('Failed to decode and download:', error)
           showErrorNotification('Download Failed', 'Failed to decode export content')

--- a/frontend/src/pages/ProjectArtefactsPage.tsx
+++ b/frontend/src/pages/ProjectArtefactsPage.tsx
@@ -42,6 +42,7 @@ import { MermaidPreviewDialog, DotPreviewDialog } from '../components/visualizat
 import { showErrorNotification, showSuccessNotification } from '../utils/notifications'
 import { PlanDagNodeType } from '../types/plan-dag'
 import { useProjectPlanSelection } from '../hooks/useProjectPlanSelection'
+import { fallbackExportFilename } from '../utils/exportFilename'
 import { cn } from '../lib/utils'
 
 const GET_PROJECTS = gql`
@@ -308,12 +309,13 @@ const [exportForPreview] = useMutation(EXPORT_NODE_OUTPUT, {
           const url = window.URL.createObjectURL(blob)
           const link = document.createElement('a')
           link.href = url
-          link.download = result.filename
+          const downloadName = result.filename || fallbackExportFilename('artefact', undefined, result.mimeType)
+          link.download = downloadName
           document.body.appendChild(link)
           link.click()
           document.body.removeChild(link)
           window.URL.revokeObjectURL(url)
-          showSuccessNotification('Download Complete', result.filename)
+          showSuccessNotification('Download Complete', downloadName)
         } catch (error) {
           console.error('Failed to decode and download export', error)
           showErrorNotification('Download Failed', 'Unable to decode export content')

--- a/frontend/src/pages/StoriesPage.tsx
+++ b/frontend/src/pages/StoriesPage.tsx
@@ -12,6 +12,7 @@ import {
   IconFileTypeCsv,
   IconBraces,
 } from '@tabler/icons-react'
+import { fallbackExportFilename } from '@/utils/exportFilename'
 import { Breadcrumbs } from '@/components/common/Breadcrumbs'
 import PageContainer from '@/components/layout/PageContainer'
 import { Group, Stack } from '@/components/layout-primitives'
@@ -120,7 +121,7 @@ export const StoriesPage = () => {
         const url = URL.createObjectURL(blob)
         const a = document.createElement('a')
         a.href = url
-        a.download = result.filename
+        a.download = result.filename || fallbackExportFilename('story', undefined, result.mimeType)
         document.body.appendChild(a)
         a.click()
         document.body.removeChild(a)

--- a/frontend/src/utils/exportFilename.ts
+++ b/frontend/src/utils/exportFilename.ts
@@ -1,0 +1,31 @@
+/**
+ * Build a download filename when an artefact export returns an empty filename
+ * (the backend does this when the node has no configured outputPath).
+ *
+ * Uses the render target / node label as the base and an extension derived from
+ * the export MIME type, so the browser never downloads a nameless file.
+ */
+const MIME_EXTENSIONS: Record<string, string> = {
+  'text/vnd.graphviz': 'dot',
+  'text/plain': 'txt',
+  'application/json': 'json',
+  'text/csv': 'csv',
+  'image/svg+xml': 'svg',
+  'text/x-plantuml': 'puml',
+  'text/x-mermaid': 'mmd',
+}
+
+export function fallbackExportFilename(
+  renderTarget: string | undefined,
+  label: string | undefined,
+  mimeType: string | undefined,
+): string {
+  const base =
+    (renderTarget || label || 'export')
+      .toString()
+      .trim()
+      .replace(/[^a-zA-Z0-9._-]+/g, '_')
+      .replace(/^_+|_+$/g, '') || 'export'
+  const ext = (mimeType && MIME_EXTENSIONS[mimeType]) || 'txt'
+  return base.includes('.') ? base : `${base}.${ext}`
+}


### PR DESCRIPTION
Found by driving the live app end-to-end. `exportNodeOutput` returns an empty `filename` when an artefact node has no configured `outputPath` — the export succeeds with valid content, but every download site did `link.download = result.filename`, producing a nameless download and an empty 'Download Complete' toast.

New `utils/exportFilename.ts` derives a name from the render target/label + a MIME-type extension, used as a fallback at all four sites (GraphArtefactNode, SequenceArtefactNode, StoriesPage, ProjectArtefactsPage).

Verified live: `exportNodeOutput` on project 24's DOT/PlantUML artefacts returns `filename=''` with valid content; the fallback now yields e.g. `DOT.dot`. Frontend tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)