### PR TITLE
Per-edit transactional replay + delta subscription plan-scoping

### DIFF
--- a/frontend/src/graphql/plan-dag.ts
+++ b/frontend/src/graphql/plan-dag.ts
@@ -311,9 +311,10 @@ export const USER_PRESENCE_SUBSCRIPTION = gql`
 
 // Delta-based subscription for JSON Patch updates
 export const PLAN_DAG_DELTA_SUBSCRIPTION = gql`
-  subscription PlanDagDeltaChanged($projectId: Int!) {
-    planDagDeltaChanged(projectId: $projectId) {
+  subscription PlanDagDeltaChanged($projectId: Int!, $planId: Int) {
+    planDagDeltaChanged(projectId: $projectId, planId: $planId) {
       projectId
+      planId
       version
       userId
       clientId

--- a/frontend/src/services/PlanDagQueryService.ts
+++ b/frontend/src/services/PlanDagQueryService.ts
@@ -88,7 +88,9 @@ export class PlanDagQueryService {
 
     const subscription = this.apollo.subscribe({
       query: PlanDagGraphQL.PLAN_DAG_DELTA_SUBSCRIPTION,
-      variables: { projectId: query.projectId }
+      // Scope to the plan being edited so a multi-plan project doesn't deliver
+      // (and misapply) a JSON patch generated for a different plan.
+      variables: { projectId: query.projectId, planId: query.planId ?? null }
     })
 
     console.log('[PlanDagQueryService] Delta subscription created, waiting for updates...')
@@ -109,6 +111,17 @@ export class PlanDagQueryService {
             fromClientId: deltaData.clientId,
             localClientId: this.clientId
           })
+
+          // Defensively ignore deltas for a different plan (the server also
+          // filters by planId, but never misapply a cross-plan JSON patch).
+          if (
+            query.planId != null &&
+            deltaData.planId != null &&
+            deltaData.planId !== query.planId
+          ) {
+            console.log('[PlanDagQueryService] Ignoring delta for a different plan', deltaData.planId)
+            return
+          }
 
           // Suppress the echo of our own mutation by comparing the originating
           // client id, not a timing window. This is causal (never drops a

--- a/layercake-core/src/services/graph_data_edit_applicator.rs
+++ b/layercake-core/src/services/graph_data_edit_applicator.rs
@@ -1,6 +1,6 @@
 use sea_orm::{
-    ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, PaginatorTrait, QueryFilter,
-    Set,
+    ActiveModelTrait, ColumnTrait, ConnectionTrait, DatabaseConnection, EntityTrait,
+    PaginatorTrait, QueryFilter, Set,
 };
 use tracing::{debug, warn};
 
@@ -32,18 +32,29 @@ impl GraphDataEditApplicator {
         Self { db }
     }
 
-    /// Apply a single graph edit to the database
+    /// Apply a single graph edit against the applicator's own connection.
     ///
-    /// Returns ApplyResult indicating success, skip, or error
+    /// Returns ApplyResult indicating success, skip, or error.
     pub async fn apply_edit(&self, edit: &graph_edits::Model) -> CoreResult<ApplyResult> {
+        self.apply_edit_on(&self.db, edit).await
+    }
+
+    /// Apply a single graph edit against the given connection (which may be a
+    /// transaction). Used by the replay loop so an edit's mutation and its
+    /// `mark_edit_applied` commit atomically.
+    pub async fn apply_edit_on<C: ConnectionTrait>(
+        &self,
+        conn: &C,
+        edit: &graph_edits::Model,
+    ) -> CoreResult<ApplyResult> {
         debug!(
             "Applying edit #{} on {}:{} ({})",
             edit.sequence_number, edit.target_type, edit.target_id, edit.operation
         );
 
         let result = match edit.target_type.as_str() {
-            "node" => self.apply_node_edit(edit).await?,
-            "edge" => self.apply_edge_edit(edit).await?,
+            "node" => self.apply_node_edit(conn, edit).await?,
+            "edge" => self.apply_edge_edit(conn, edit).await?,
             "layer" => {
                 // Layer edits are skipped for graph_data - Phase 5 will remove layer storage
                 ApplyResult::Skipped {
@@ -63,23 +74,31 @@ impl GraphDataEditApplicator {
     }
 
     /// Apply edit to a graph_data node
-    async fn apply_node_edit(&self, edit: &graph_edits::Model) -> CoreResult<ApplyResult> {
+    async fn apply_node_edit<C: ConnectionTrait>(
+        &self,
+        conn: &C,
+        edit: &graph_edits::Model,
+    ) -> CoreResult<ApplyResult> {
         match edit.operation.as_str() {
-            "create" => self.create_node(edit).await,
-            "update" => self.update_node(edit).await,
-            "delete" => self.delete_node(edit).await,
+            "create" => self.create_node(conn, edit).await,
+            "update" => self.update_node(conn, edit).await,
+            "delete" => self.delete_node(conn, edit).await,
             _ => Ok(ApplyResult::Error {
                 reason: format!("Unknown node operation: {}", edit.operation),
             }),
         }
     }
 
-    async fn create_node(&self, edit: &graph_edits::Model) -> CoreResult<ApplyResult> {
+    async fn create_node<C: ConnectionTrait>(
+        &self,
+        conn: &C,
+        edit: &graph_edits::Model,
+    ) -> CoreResult<ApplyResult> {
         // Check if node already exists
         let existing = GraphDataNodes::find()
             .filter(graph_data_nodes::Column::GraphDataId.eq(edit.graph_id))
             .filter(graph_data_nodes::Column::ExternalId.eq(&edit.target_id))
-            .one(&self.db)
+            .one(conn)
             .await
             .map_err(|e| CoreError::internal("Failed to load graph_data node").with_source(e))?;
 
@@ -138,7 +157,7 @@ impl GraphDataEditApplicator {
             created_at: Set(chrono::Utc::now()),
         };
 
-        node.insert(&self.db)
+        node.insert(conn)
             .await
             .map_err(|e| CoreError::internal("Failed to create graph_data node").with_source(e))?;
 
@@ -147,11 +166,15 @@ impl GraphDataEditApplicator {
         })
     }
 
-    async fn update_node(&self, edit: &graph_edits::Model) -> CoreResult<ApplyResult> {
+    async fn update_node<C: ConnectionTrait>(
+        &self,
+        conn: &C,
+        edit: &graph_edits::Model,
+    ) -> CoreResult<ApplyResult> {
         let node = GraphDataNodes::find()
             .filter(graph_data_nodes::Column::GraphDataId.eq(edit.graph_id))
             .filter(graph_data_nodes::Column::ExternalId.eq(&edit.target_id))
-            .one(&self.db)
+            .one(conn)
             .await
             .map_err(|e| CoreError::internal("Failed to load graph_data node").with_source(e))?;
 
@@ -199,7 +222,7 @@ impl GraphDataEditApplicator {
         }
 
         active_model
-            .update(&self.db)
+            .update(conn)
             .await
             .map_err(|e| CoreError::internal("Failed to update graph_data node").with_source(e))?;
 
@@ -211,11 +234,15 @@ impl GraphDataEditApplicator {
         })
     }
 
-    async fn delete_node(&self, edit: &graph_edits::Model) -> CoreResult<ApplyResult> {
+    async fn delete_node<C: ConnectionTrait>(
+        &self,
+        conn: &C,
+        edit: &graph_edits::Model,
+    ) -> CoreResult<ApplyResult> {
         let result = GraphDataNodes::delete_many()
             .filter(graph_data_nodes::Column::GraphDataId.eq(edit.graph_id))
             .filter(graph_data_nodes::Column::ExternalId.eq(&edit.target_id))
-            .exec(&self.db)
+            .exec(conn)
             .await
             .map_err(|e| CoreError::internal("Failed to delete graph_data node").with_source(e))?;
 
@@ -231,23 +258,31 @@ impl GraphDataEditApplicator {
     }
 
     /// Apply edit to a graph_data edge
-    async fn apply_edge_edit(&self, edit: &graph_edits::Model) -> CoreResult<ApplyResult> {
+    async fn apply_edge_edit<C: ConnectionTrait>(
+        &self,
+        conn: &C,
+        edit: &graph_edits::Model,
+    ) -> CoreResult<ApplyResult> {
         match edit.operation.as_str() {
-            "create" => self.create_edge(edit).await,
-            "update" => self.update_edge(edit).await,
-            "delete" => self.delete_edge(edit).await,
+            "create" => self.create_edge(conn, edit).await,
+            "update" => self.update_edge(conn, edit).await,
+            "delete" => self.delete_edge(conn, edit).await,
             _ => Ok(ApplyResult::Error {
                 reason: format!("Unknown edge operation: {}", edit.operation),
             }),
         }
     }
 
-    async fn create_edge(&self, edit: &graph_edits::Model) -> CoreResult<ApplyResult> {
+    async fn create_edge<C: ConnectionTrait>(
+        &self,
+        conn: &C,
+        edit: &graph_edits::Model,
+    ) -> CoreResult<ApplyResult> {
         // Check if edge already exists
         let existing = GraphDataEdges::find()
             .filter(graph_data_edges::Column::GraphDataId.eq(edit.graph_id))
             .filter(graph_data_edges::Column::ExternalId.eq(&edit.target_id))
-            .one(&self.db)
+            .one(conn)
             .await
             .map_err(|e| CoreError::internal("Failed to load graph_data edge").with_source(e))?;
 
@@ -278,7 +313,7 @@ impl GraphDataEditApplicator {
         let source_exists = GraphDataNodes::find()
             .filter(graph_data_nodes::Column::GraphDataId.eq(edit.graph_id))
             .filter(graph_data_nodes::Column::ExternalId.eq(&source))
-            .count(&self.db)
+            .count(conn)
             .await
             .map_err(|e| CoreError::internal("Failed to load graph_data node").with_source(e))?
             > 0;
@@ -286,7 +321,7 @@ impl GraphDataEditApplicator {
         let target_exists = GraphDataNodes::find()
             .filter(graph_data_nodes::Column::GraphDataId.eq(edit.graph_id))
             .filter(graph_data_nodes::Column::ExternalId.eq(&target))
-            .count(&self.db)
+            .count(conn)
             .await
             .map_err(|e| CoreError::internal("Failed to load graph_data node").with_source(e))?
             > 0;
@@ -334,7 +369,7 @@ impl GraphDataEditApplicator {
             created_at: Set(chrono::Utc::now()),
         };
 
-        edge.insert(&self.db)
+        edge.insert(conn)
             .await
             .map_err(|e| CoreError::internal("Failed to create graph_data edge").with_source(e))?;
 
@@ -343,11 +378,15 @@ impl GraphDataEditApplicator {
         })
     }
 
-    async fn update_edge(&self, edit: &graph_edits::Model) -> CoreResult<ApplyResult> {
+    async fn update_edge<C: ConnectionTrait>(
+        &self,
+        conn: &C,
+        edit: &graph_edits::Model,
+    ) -> CoreResult<ApplyResult> {
         let edge = GraphDataEdges::find()
             .filter(graph_data_edges::Column::GraphDataId.eq(edit.graph_id))
             .filter(graph_data_edges::Column::ExternalId.eq(&edit.target_id))
-            .one(&self.db)
+            .one(conn)
             .await
             .map_err(|e| CoreError::internal("Failed to load graph_data edge").with_source(e))?;
 
@@ -387,7 +426,7 @@ impl GraphDataEditApplicator {
         }
 
         active_model
-            .update(&self.db)
+            .update(conn)
             .await
             .map_err(|e| CoreError::internal("Failed to update graph_data edge").with_source(e))?;
 
@@ -399,11 +438,15 @@ impl GraphDataEditApplicator {
         })
     }
 
-    async fn delete_edge(&self, edit: &graph_edits::Model) -> CoreResult<ApplyResult> {
+    async fn delete_edge<C: ConnectionTrait>(
+        &self,
+        conn: &C,
+        edit: &graph_edits::Model,
+    ) -> CoreResult<ApplyResult> {
         let result = GraphDataEdges::delete_many()
             .filter(graph_data_edges::Column::GraphDataId.eq(edit.graph_id))
             .filter(graph_data_edges::Column::ExternalId.eq(&edit.target_id))
-            .exec(&self.db)
+            .exec(conn)
             .await
             .map_err(|e| CoreError::internal("Failed to delete graph_data edge").with_source(e))?;
 

--- a/layercake-core/src/services/graph_data_service.rs
+++ b/layercake-core/src/services/graph_data_service.rs
@@ -639,8 +639,18 @@ impl GraphDataService {
 
     /// Mark an edit as applied
     pub async fn mark_edit_applied(&self, edit_id: i32) -> CoreResult<()> {
+        self.mark_edit_applied_on(&self.db, edit_id).await
+    }
+
+    /// Mark an edit as applied against the given connection (which may be a
+    /// transaction), so it can commit atomically with the edit's own mutation.
+    async fn mark_edit_applied_on<C: sea_orm::ConnectionTrait>(
+        &self,
+        conn: &C,
+        edit_id: i32,
+    ) -> CoreResult<()> {
         let edit = GraphEdits::find_by_id(edit_id)
-            .one(&self.db)
+            .one(conn)
             .await
             .map_err(|e| CoreError::internal("Failed to load graph edit").with_source(e))?
             .ok_or_else(|| CoreError::not_found("GraphEdit", edit_id.to_string()))?;
@@ -648,7 +658,7 @@ impl GraphDataService {
         let mut active_model: graph_edits::ActiveModel = edit.into();
         active_model.applied = Set(true);
         active_model
-            .update(&self.db)
+            .update(conn)
             .await
             .map(|_| ())
             .map_err(|e| CoreError::internal("Failed to mark edit applied").with_source(e))
@@ -697,14 +707,36 @@ impl GraphDataService {
         // Create applicator
         let applicator = GraphDataEditApplicator::new(self.db.clone());
 
-        // Apply each edit in sequence
+        // Apply each edit in sequence. Each edit runs in its own transaction so
+        // its mutation and its applied-marker commit atomically: on a crash an
+        // edit is never left applied-in-data-but-unmarked (or vice versa), and a
+        // subsequent replay resumes cleanly from the first unapplied edit.
         for edit in edits {
             debug!(
                 "Replaying edit #{}: {} {} {}",
                 edit.sequence_number, edit.operation, edit.target_type, edit.target_id
             );
 
-            match applicator.apply_edit(&edit).await {
+            // Run apply + mark-applied inside one transaction. The closure
+            // returns the ApplyResult; on Success we also mark it applied before
+            // committing. Skipped/Error results still commit (no data mutation
+            // that needs rolling back, but the txn cleanly closes).
+            let txn_result: CoreResult<ApplyResult> = async {
+                let txn = self.db.begin().await.map_err(|e| {
+                    CoreError::internal("Failed to begin replay transaction").with_source(e)
+                })?;
+                let apply = applicator.apply_edit_on(&txn, &edit).await?;
+                if matches!(apply, ApplyResult::Success { .. }) {
+                    self.mark_edit_applied_on(&txn, edit.id).await?;
+                }
+                txn.commit().await.map_err(|e| {
+                    CoreError::internal("Failed to commit replay transaction").with_source(e)
+                })?;
+                Ok(apply)
+            }
+            .await;
+
+            match txn_result {
                 Ok(ApplyResult::Success { message }) => {
                     summary.applied += 1;
                     summary.details.push(GraphDataEditResult {
@@ -715,11 +747,6 @@ impl GraphDataService {
                         result: "success".to_string(),
                         message,
                     });
-
-                    // Mark as applied
-                    if let Err(e) = self.mark_edit_applied(edit.id).await {
-                        warn!("Failed to mark edit {} as applied: {}", edit.id, e);
-                    }
                 }
                 Ok(ApplyResult::Skipped { reason }) => {
                     summary.skipped += 1;

--- a/layercake-core/tests/graph_data_integrity_test.rs
+++ b/layercake-core/tests/graph_data_integrity_test.rs
@@ -494,3 +494,104 @@ async fn app_replay_graph_edits_applies_on_graph_data() {
         .unwrap();
     assert!(node.is_some(), "replayed edit should create the node");
 }
+
+// --- Per-edit transactional replay (Horizon 1 deferral, now implemented) ---
+//
+// Each edit's data mutation and its applied-marker commit in one transaction.
+// This test drives create+update+delete over several edits and asserts that,
+// after replay, every applied edit's data effect is present AND it is marked
+// applied — never a partial state — and a re-replay is a no-op.
+#[tokio::test]
+async fn replay_marks_and_applies_each_edit_atomically() {
+    use layercake_core::database::entities::graph_edits;
+
+    let db = setup_test_db().await.unwrap();
+    ensure_project(&db, 1).await;
+    let gd_service = GraphDataService::new(db.clone());
+    let gd = create_graph_data(&gd_service, 1).await;
+
+    async fn insert_edit(
+        db: &DatabaseConnection,
+        graph_id: i32,
+        seq: i32,
+        target: &str,
+        op: &str,
+        field: Option<&str>,
+        new_value: serde_json::Value,
+    ) {
+        graph_edits::ActiveModel {
+            id: sea_orm::ActiveValue::NotSet,
+            graph_id: Set(graph_id),
+            target_type: Set("node".to_string()),
+            target_id: Set(target.to_string()),
+            operation: Set(op.to_string()),
+            field_name: Set(field.map(|s| s.to_string())),
+            old_value: Set(None),
+            new_value: Set(Some(new_value)),
+            sequence_number: Set(seq),
+            applied: Set(false),
+            created_at: Set(chrono::Utc::now()),
+            created_by: Set(None),
+        }
+        .insert(db)
+        .await
+        .unwrap();
+    }
+
+    // create n1, update n1.label, create n2, delete n2  -> final: only n1 (label "Renamed")
+    insert_edit(
+        &db,
+        gd.id,
+        1,
+        "n1",
+        "create",
+        None,
+        json!({"label": "First"}),
+    )
+    .await;
+    insert_edit(
+        &db,
+        gd.id,
+        2,
+        "n1",
+        "update",
+        Some("label"),
+        json!("Renamed"),
+    )
+    .await;
+    insert_edit(&db, gd.id, 3, "n2", "create", None, json!({"label": "Two"})).await;
+    insert_edit(&db, gd.id, 4, "n2", "delete", None, json!({})).await;
+
+    let summary = gd_service.replay_edits(gd.id).await.unwrap();
+    assert_eq!(summary.applied, 4, "all four edits applied");
+
+    // Data effect: only n1 remains, renamed.
+    let nodes = graph_data_nodes::Entity::find()
+        .filter(graph_data_nodes::Column::GraphDataId.eq(gd.id))
+        .all(&db)
+        .await
+        .unwrap();
+    assert_eq!(nodes.len(), 1);
+    assert_eq!(nodes[0].external_id, "n1");
+    assert_eq!(nodes[0].label.as_deref(), Some("Renamed"));
+
+    // Every edit is marked applied (marker committed with the data mutation).
+    let unapplied = graph_edits::Entity::find()
+        .filter(graph_edits::Column::GraphId.eq(gd.id))
+        .filter(graph_edits::Column::Applied.eq(false))
+        .all(&db)
+        .await
+        .unwrap();
+    assert!(unapplied.is_empty(), "no edit left unapplied after replay");
+
+    // Re-replay is a no-op (nothing left to apply) — proves marker+data are consistent.
+    let again = gd_service.replay_edits(gd.id).await.unwrap();
+    assert_eq!(again.applied, 0);
+    let count = graph_data_nodes::Entity::find()
+        .filter(graph_data_nodes::Column::GraphDataId.eq(gd.id))
+        .all(&db)
+        .await
+        .unwrap()
+        .len();
+    assert_eq!(count, 1, "re-replay did not duplicate or alter data");
+}

--- a/layercake-server/src/graphql/mutations/plan_dag_delta.rs
+++ b/layercake-server/src/graphql/mutations/plan_dag_delta.rs
@@ -133,8 +133,10 @@ pub async fn fetch_current_plan_dag(
 }
 
 /// Publish a delta event after a mutation
+#[allow(clippy::too_many_arguments)]
 pub async fn publish_plan_dag_delta(
     project_id: i32,
+    plan_id: i32,
     version: i32,
     user_id: String,
     client_id: String,
@@ -142,6 +144,7 @@ pub async fn publish_plan_dag_delta(
 ) -> Result<(), String> {
     let event = PlanDagDeltaEvent {
         project_id,
+        plan_id,
         version,
         user_id,
         client_id,

--- a/layercake-server/src/graphql/subscriptions/mod.rs
+++ b/layercake-server/src/graphql/subscriptions/mod.rs
@@ -260,22 +260,28 @@ impl Subscription {
     // Real-time presence data is available through the WebSocket collaboration system at /ws/collaboration
 
     /// Subscribe to Plan DAG delta changes (JSON Patch format) for efficient updates
+    ///
+    /// When `plan_id` is provided, only deltas for that plan are delivered, so a
+    /// client editing one plan of a multi-plan project never receives (and
+    /// misapplies) a patch generated for a different plan.
     async fn plan_dag_delta_changed(
         &self,
         ctx: &Context<'_>,
         project_id: i32,
+        plan_id: Option<i32>,
     ) -> Result<Pin<Box<dyn Stream<Item = PlanDagDeltaEvent> + Send>>> {
         let _context = ctx.data::<GraphQLContext>()?;
 
         // Subscribe to delta events for this project
         let mut receiver = DELTA_EVENTS.subscribe(project_id).await;
 
-        // Stream delta events for this project
+        // Stream delta events for this project (and plan, if specified)
         let stream = async_stream::stream! {
             loop {
                 match receiver.recv().await {
                     Ok(event) => {
-                        if event.project_id == project_id {
+                        let plan_matches = plan_id.map_or(true, |pid| event.plan_id == pid);
+                        if event.project_id == project_id && plan_matches {
                             yield event;
                         }
                     }

--- a/layercake-server/src/graphql/types/json_patch.rs
+++ b/layercake-server/src/graphql/types/json_patch.rs
@@ -60,6 +60,11 @@ pub struct PlanDagDeltaEvent {
     /// Project ID
     pub project_id: i32,
 
+    /// Plan ID the delta applies to. A project can have multiple plans; a
+    /// subscriber must ignore deltas for plans other than the one it is editing,
+    /// otherwise a JSON patch for a different plan would be misapplied.
+    pub plan_id: i32,
+
     /// New version after applying patch
     pub version: i32,
 


### PR DESCRIPTION
## Per-edit transactional replay + delta subscription plan-scoping

Implements the two remaining follow-ups from the Horizon 1 / frontend-bug work.

### 1. Per-edit transaction in the graph-data applicator (Horizon 1 deferral)
Replay applied an edit's **data mutation** and its **`mark_edit_applied`** as two separate writes. A crash between them could leave an edit applied-in-data-but-unmarked (re-applied on the next replay) or marked-but-not-applied.

- Threaded a `ConnectionTrait` generic through `GraphDataEditApplicator` (`apply_edit_on`) and added `mark_edit_applied_on`.
- The replay loop now runs **apply + mark inside one transaction per edit** that commits atomically. Public `apply_edit()` / `mark_edit_applied()` remain as thin wrappers.
- New test `replay_marks_and_applies_each_edit_atomically` (create/update/delete over several edits → no partial state, idempotent re-replay).

### 2. Delta subscription plan-scoping
A project can have multiple plans, but the delta subscription was keyed only by `projectId`, so a client editing one plan could receive and **misapply a JSON patch generated for a different plan**.

- Added `plan_id` to `PlanDagDeltaEvent` and `publish_plan_dag_delta`.
- `plan_dag_delta_changed` takes an optional `planId` and only yields matching events.
- Frontend passes `planId` in the subscription variables (previously **dropped**) and defensively ignores deltas whose `planId` differs.

**Note:** the delta publish path is still dormant (no server-side publisher yet), so this hardens it ahead of wiring rather than fixing an active runtime bug.

### Verification
`layercake-core` 256 pass / 0 fail (incl. new atomicity test) · `layercake-server` all tests pass (incl. golden schema) · frontend tsc + vite build clean · clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
