### PR TITLE
docs: data model direction assessment + Phase 0 cutover plan

### DIFF
--- a/plans/20260710-phase0-graph-data-cutover.md
+++ b/plans/20260710-phase0-graph-data-cutover.md
@@ -1,0 +1,187 @@
+# Phase 0 — Complete the graph_data single-schema cutover
+
+**Date:** 2026-07-10
+**Status:** In progress
+**Owner:** Data model direction workstream
+**Related:**
+`reviews/20260710-data-model-direction-roadmap.md` (§15 Phase 0),
+`reviews/20260710-data-model-direction-assessment.md`
+
+---
+
+## 1. Goal
+
+Finish the graph_data cutover so that **no source code references a table that
+`m20251215_000001_drop_legacy_graph_tables` has already dropped**, and prove it with
+a repeatable check. This is the hard gate that must close before any semantic-layer
+work (Phases 1+) begins.
+
+Dropped tables that must have zero remaining code references (outside `migrations/`):
+
+- `graphs`
+- `graph_nodes`
+- `graph_edges`
+- `graph_layers`
+- `dataset_graph_nodes`
+- `dataset_graph_edges`
+- `dataset_graph_layers`
+
+Authoritative replacements:
+
+| Legacy table | Canonical replacement |
+|---|---|
+| `graphs` | `graph_data` |
+| `graph_nodes` | `graph_data_nodes` |
+| `graph_edges` | `graph_data_edges` |
+| `graph_layers` | `project_layers` (project-scoped layers) |
+| `dataset_graph_nodes` | `graph_data_nodes` (of the dataset's `graph_data` row) |
+| `dataset_graph_edges` | `graph_data_edges` (of the dataset's `graph_data` row) |
+| `dataset_graph_layers` | `project_layers` |
+
+**Not in scope:** any new semantic tables (record types, assertions, dimensions,
+provenance). Those are Phases 1+. `data_sets`, `dataset_nodes`, `dataset_rows`,
+`graph_edits`, `graph_data*`, `project_layers`, `layer_aliases` are current and stay.
+
+---
+
+## 2. Why this is a gate (evidence)
+
+The legacy tables are gone from the database but not from the code, so several
+reachable paths query tables that no longer exist:
+
+- `graphql/queries/mod.rs:109,127` → `data_set_service::get_graph_summary` /
+  `get_graph_page` → `dataset_graph_*` (dropped). Dataset preview is broken.
+- `services/graph_edit_service.rs:137-158` → `else` branch loads/updates `graphs`
+  (dropped).
+- `pipeline/dag_executor.rs`, `pipeline/merge_builder.rs`,
+  `services/graph_service.rs` → "fall back to legacy `graphs` table" branches
+  (dropped).
+- `app_context/graph_operations.rs`, `services/import_service.rs` → write/read
+  `graph_layers` / `graph_nodes` (dropped).
+- `graphql/types/{graph,graph_node,graph_edge,preview}.rs` → map `graphs::Model` /
+  `graph_nodes::Model` / `graph_edges::Model` (dropped).
+
+`m20260709_000001_rebuild_graph_edits_drop_graphs_fk` already had to fix one silent
+breakage (a dangling `graph_edits → graphs` FK) caused by this same incomplete drop.
+
+---
+
+## 3. Verification method
+
+Environment note: the full workspace build fails on `src-tauri` (`gdk-sys` needs
+system GTK not installed here). Phase 0 code is entirely in `layercake-core`,
+`layercake-server`, `layercake-cli`, so verification uses:
+
+```bash
+# 1. No legacy table references remain in source (outside migrations).
+grep -rnE '\b(graphs|graph_nodes|graph_edges|graph_layers|dataset_graph_nodes|dataset_graph_edges|dataset_graph_layers)\b' \
+  layercake-core/src layercake-server/src layercake-cli/src layercake-projections/src \
+  | grep -v '/migrations/'
+# expected: no entity/table hits (comments mentioning history are fine)
+
+# 2. Targeted build.
+cargo build -p layercake-core -p layercake-server -p layercake-cli
+
+# 3. Targeted tests.
+cargo test -p layercake-core -p layercake-server -p layercake-cli
+```
+
+A guard test in `layercake-core` will assert the entity modules are gone so the
+regression cannot silently return.
+
+---
+
+## 4. Workstreams
+
+Each workstream is independently compilable and committed separately. Ordering is
+chosen so the tree keeps building between commits (leaf rewrites first, entity-module
+deletion last).
+
+### WS1 — Dataset preview/summary → graph_data
+**Files:** `services/data_set_service.rs` (`get_graph_summary` ~L474, `get_graph_page`
+~L520, `update_graph_data` cleanup ~L291-300), import (`data_sets` L11).
+**Action:** Resolve a `data_sets` row to its `graph_data` row (dataset import writes
+`graph_data` with `source_type='dataset'`; confirm the link — `graph_data.name`/a
+dataset id in metadata, or a lookup by dataset). Read nodes/edges from
+`graph_data_nodes`/`graph_data_edges`; derive layers from `project_layers`. Drop the
+`dataset_graph_layers` delete in `update_graph_data`.
+
+### WS2 — DAG executor / merge builder / graph_service legacy fallbacks
+**Files:** `pipeline/dag_executor.rs` (fallbacks ~L922, L1062, L1767; in-memory
+`graphs::Model` for hashing ~L900, L1040; helper sigs ~L1255, L1273),
+`pipeline/merge_builder.rs` (~L245), `services/graph_service.rs` (~L266 fallback,
+`graph_layers` reads/writes L252-259, 675-684).
+**Action:** Delete every "fall back to legacy `graphs` table" branch (graph_data is
+now the only source; return a proper not-found error instead). Replace the in-memory
+`graphs::Model` built for hash input with a small local struct or by passing the
+needed fields directly; update the two helpers that take `&graphs::Model`. Repoint
+`graph_service` layer accessors to `project_layers`.
+
+### WS3 — Layer/node editing methods → project_layers / graph_data
+**Files:** `app_context/graph_operations.rs` (`create_layer` L71, `update_layer`
+L410, node edit via `graph_nodes` L297), `services/import_service.rs` (`graph_layers`
+write L89).
+**Action:** Determine reachability (GraphQL mutations). Repoint layer create/update
+to `project_layers`; repoint node editing to `graph_data_nodes`. If a method is
+superseded by an existing graph_data path, remove it and its wiring rather than
+rewire.
+
+### WS4 — graph_edit_service else-branch
+**Files:** `services/graph_edit_service.rs` (L137-158, L216-..., L283-...).
+**Action:** `graph_id` is always a `graph_data` id in the current schema (see
+`graph_operations.rs:590-593`). Remove the `graphs` `else` branches; when the id is
+absent from `graph_data`, return `not_found` instead of touching a dropped table.
+
+### WS5 — GraphQL legacy type mappers
+**Files:** `graphql/types/graph.rs` (L125 `From<graphs::Model>`, resolvers L68/106/115),
+`graph_node.rs` (L39), `graph_edge.rs` (L25), `preview.rs` (L82,112).
+**Action:** Remove `From<legacy::Model>` impls and any resolver that reads a dropped
+table. Where a GraphQL type is still served, populate it from `graph_data*`
+/`project_layers`. Delete now-unused GraphQL fields only if nothing in the schema
+depends on them; otherwise back them with graph_data.
+
+### WS6 — Delete legacy entity modules
+**Files:** `database/entities/mod.rs` (L23-33), and delete
+`entities/{graphs,graph_nodes,graph_edges,graph_layers,dataset_graph_nodes,dataset_graph_edges,dataset_graph_layers}.rs`;
+remove the `graphs` relation from `entities/graph_edits.rs` (L31-42). Review the
+`pub use dataset_nodes as datasets` alias (L45) — keep only if still referenced.
+**Action:** Delete modules and fix `mod.rs`. This must be the last step; it will not
+compile until WS1–WS5 remove all callers.
+
+### WS7 — Guard + verification
+**Files:** new test in `layercake-core` (e.g. a compile-time/reference guard) plus a
+short note in `LAYERCAKE_MODEL_GUIDE.md` recording the single-path invariant.
+**Action:** Add a test asserting the cutover invariant and run §3 checks. Optionally
+wire the grep guard into CI.
+
+---
+
+## 5. Progress tracker
+
+Legend: ☐ not started · ◐ in progress · ☑ done · ⚠ blocked/needs decision
+
+| WS | Description | Status | Notes |
+|----|-------------|--------|-------|
+| — | Baseline: targeted build of core/server/cli green | ☑ | `cargo build -p layercake-core -p layercake-server -p layercake-cli` exit 0 |
+| WS1 | Dataset preview/summary → graph_data | ☐ | |
+| WS2 | DAG/merge/graph_service legacy fallbacks removed | ☐ | |
+| WS3 | Layer/node editing → project_layers/graph_data | ☐ | |
+| WS4 | graph_edit_service else-branch removed | ☐ | |
+| WS5 | GraphQL legacy mappers removed/repointed | ☐ | |
+| WS6 | Legacy entity modules deleted | ☐ | last; blocks build until WS1–5 done |
+| WS7 | Guard test + verification (§3) | ☐ | |
+
+### Change log
+
+- 2026-07-10 — Plan created; legacy-reference inventory completed (12 source files).
+  Review and assessment updated to promote Phase 0 to a verified gate.
+
+---
+
+## 6. Exit criteria
+
+- §3 grep returns no legacy entity/table references outside `migrations/`.
+- `cargo build -p layercake-core -p layercake-server -p layercake-cli` is green.
+- `cargo test` for those crates is green.
+- Legacy entity modules are deleted; `entities/mod.rs` no longer declares them.
+- Guard test in place so the regression cannot silently return.

--- a/reviews/20260710-data-model-direction-assessment.md
+++ b/reviews/20260710-data-model-direction-assessment.md
@@ -1,0 +1,242 @@
+# Assessment of the Data Model Direction and Roadmap Review
+
+**Date:** 2026-07-10
+**Status:** Independent validation and critique
+**Reviews:** `reviews/20260710-data-model-direction-roadmap.md`
+**Repository:** `michiel/layercake-tool`
+
+---
+
+## 1. Purpose
+
+This document validates the factual claims in the data model direction review, then
+offers an independent assessment of the recommended direction. It is deliberately
+critical rather than confirmatory: the review is a strong piece of architecture
+writing, and the most useful contribution here is to test its premises against the
+code and to flag where its sequencing and risk weighting need adjustment.
+
+Short version:
+
+- The review's description of the **current schema is accurate**; every structural
+  claim was checked against the entities and migrations and holds.
+- The review's **central diagnosis is sound**: the model is graph-centric and
+  conflates source, canonical, view, and rendered concerns.
+- The review's **Phase 0 premise is not just theoretically correct — it is
+  demonstrably unfinished today**, with live code still reading tables that
+  migrations have dropped. This raises the priority of Phase 0 above where the
+  review places it.
+- The **target model (typed records + reified assertions + classifications +
+  provenance, with GraphData as a materialised view) is a sound, conventional
+  design.** The main reservations are about **scope, sequencing, and a re-introduced
+  dual-write hazard**, not about the destination.
+
+---
+
+## 2. Validation of the review's factual claims
+
+All claims below were checked directly against the code.
+
+| Review claim | Verdict | Evidence |
+|---|---|---|
+| Nodes have `external_id`, `label`, `layer`, `weight`, `is_partition`, `belongs_to`, `comment`, `source_dataset_id`, `attributes`; no semantic type (§4.1) | **Confirmed** | `layercake-core/src/database/entities/graph_data_nodes.rs:16-32` |
+| Edges have `label`, `layer`, `weight`, `comment`, `source_dataset_id`, `attributes`; no first-class relationship type (§4.2) | **Confirmed** | `graph_data_edges.rs:15-31` |
+| Provenance is a single optional `source_dataset_id` per element (§4.3) | **Confirmed** | `graph_data_nodes.rs:28`, `graph_data_edges.rs:27`; merge copies one source (`merge_builder.rs:211,226`) |
+| `graph_data` couples source-file metadata (blob, filename, file_size) with computed-graph lifecycle fields (§4.4) | **Confirmed** | `graph_data.rs:33-49` |
+| `source_type` mixes resource/derivation/authorship dimensions: `dataset` / `computed` / `manual` (§4.5) | **Confirmed** | `graph_data.rs:30,101-119` |
+| A single scalar `layer` on nodes and edges (§4.6) | **Confirmed** | `graph_data_nodes.rs:22`, `graph_data_edges.rs:23` |
+| Partitions conflate display containment and domain hierarchy via `is_partition` + `belongs_to`; partitions cannot be edge endpoints (§4.7) | **Confirmed** | `graph_data_nodes.rs:24-25`; `LAYERCAKE_MODEL_GUIDE.md` "Partition Rules" |
+| Graph-specific columns (`weight`, `is_partition`, `belongs_to`) are first-class while domain concepts sit in JSON (§4.8) | **Confirmed** | as above |
+| Project layers carry stable id, name, three colours, optional dataset, alias (§2.5) | **Confirmed** | `project_layers.rs:6-20`; separate `layer_aliases.rs` table also exists |
+
+**Conclusion:** the review is an accurate reading of the code. It is not arguing
+against a straw model.
+
+---
+
+## 3. The decisive finding: the current cutover is genuinely incomplete
+
+The review's Phase 0 ("finish the single-schema migration") is presented as
+stabilisation before the interesting work. Investigation shows this is understated:
+**the graph_data cutover is not finished, and the gap is producing latent runtime
+failures, not just tidiness debt.**
+
+Evidence:
+
+1. **Legacy tables are dropped, but live services still query them.**
+   `m20251215_000001_drop_legacy_graph_tables` drops `graphs`, `graph_nodes`,
+   `graph_edges`, `dataset_graph_nodes`, `dataset_graph_edges`,
+   `dataset_graph_layers`. Yet:
+   - `services/data_set_service.rs` still reads `dataset_graph_nodes` /
+     `dataset_graph_edges` in `get_graph_summary` (`:480-486`) and `get_graph_page`
+     (`:529-552`), and deletes them in `update_graph_data` (`:291-296`) — these are
+     dataset preview/summary paths against dropped tables.
+   - `services/merge_builder.rs:245` runs a `legacy_graph = GraphEntity::find()`
+     fallback against the dropped `graphs` table.
+   - `services/graph_edit_service.rs:137-158` has an `else` branch that loads and
+     updates a row from the dropped `graphs` table when an id is absent from
+     `graph_data`.
+   - GraphQL still maps from `graphs::Model`, `graph_nodes::Model`,
+     `graph_edges::Model` (`graphql/types/graph.rs`, `graph_node.rs`,
+     `graph_edge.rs`, `preview.rs`).
+
+2. **A silent breakage from the same incomplete drop was fixed this month.**
+   `m20260709_000001_rebuild_graph_edits_drop_graphs_fk` (dated today, 2026-07-09)
+   documents that dropping `graphs` left a dangling foreign key on `graph_edits`,
+   so "every insert into `graph_edits` then fails ... which silently breaks the
+   entire graph-edit tracking / replay feature." This is precisely the class of
+   hidden-legacy-read hazard Phase 0 is meant to eliminate, discovered reactively
+   rather than by the telemetry/constraints the review recommends.
+
+The primary write paths *were* migrated correctly — `pipeline/dataset_importer.rs`
+imports into `graph_data` (`:90-159`) and `pipeline/dag_executor.rs` persists merge
+and graph output into `graph_data` (`:155-211`). So the cutover is roughly
+"happy-path done, edges of the surface still on dropped tables."
+
+**Implication for the roadmap:** Phase 0 should be treated as a hard gate with a
+higher bar than the review implies, and it should be *verified*, not assumed:
+
+- delete or rewrite every reference to `graphs`, `graph_nodes`, `graph_edges`,
+  `dataset_graph_*` (the entity modules themselves are still declared in
+  `entities/mod.rs:29-33` and should go once callers are gone);
+- add the "no legacy read" telemetry the review lists in Phase 0 deliverables
+  *before* trusting the cutover;
+- only then start semantic expansion.
+
+Adding ~20 new tables on top of a surface that still half-references dropped tables
+would compound the exact failure mode already observed.
+
+---
+
+## 4. Assessment of the recommended direction
+
+### 4.1 Where the direction is right
+
+- **Canonical records + reified assertions, with GraphData as a materialised
+  view**, is a conventional and durable pattern (a lightweight property-graph over
+  relational storage). It is the correct answer to the stated consulting use case,
+  where the "facts" are tabular/documentary and the graph is one projection.
+- **PostgreSQL + JSONB + join tables + recursive CTEs** (§13) is the pragmatic
+  choice. The explicit rejection of a native graph DB / triple store / generic EAV
+  is correct for this team and workload.
+- **Separating classification (dimensions) from presentation (layers/themes)**
+  (§4.6, §5.6) matches the evident intent of the existing alias mechanism and is
+  the single highest-value modelling change for the consulting use case.
+- **One application-service layer shared by UI/GraphQL/CLI/MCP** (§11.1) is right
+  and is independently justified: the legacy-read problems in §3 exist partly
+  because graph access is not funnelled through one service boundary.
+- **Multi-source provenance and explicit identity reconciliation** (§4.3, §4.9)
+  are genuine requirements for consulting-grade lineage, not gold-plating.
+
+### 4.2 Where I would push back
+
+1. **Scope is larger than the "evolutionary, not a rewrite" framing admits.**
+   Eight phases and ~20 new tables is a multi-quarter programme. The repository's
+   signals — a single normalised-graph ADR, an early-integration `status` file, a
+   just-fixed migration bug — indicate a small team still stabilising the *last*
+   unification. The dominant risk is not "overengineering an ontology" (the review's
+   headline risk); it is **a permanently half-migrated system**, which already
+   exists in miniature. The roadmap should be scoped so that every phase leaves the
+   system in a shippable, single-authority state.
+
+2. **§15 (horizontal phases) contradicts §17 (vertical slice), and §17 is right.**
+   The phased roadmap builds each layer broadly (all record types, then all
+   provenance, then all dimensions, then views). The "concrete first slice" builds
+   one control-ownership product end-to-end. These are different strategies. Building
+   horizontally means none of the semantic investment produces a user-visible product
+   until Phase 5+. I would **invert the roadmap around §17**: implement the
+   control-ownership slice as a thin vertical (a few record types, a handful of
+   relationship types, one dimension set, one AnalysisFrame, graph + matrix
+   projectors) *before* generalising any layer. If the consulting product does not
+   land, most of Phases 1–4 is over-build.
+
+3. **Reified assertions re-introduce the dual-write problem the graph_data cutover
+   just fought.** The proposal keeps GraphData edges as materialisations of canonical
+   assertions, with optional `assertion_id` / `record_id` back-references on
+   GraphData rows (§6). That is two stores of the same relationship with a
+   synchronisation contract — structurally identical to the `graphs` vs `graph_data`
+   split whose incomplete resolution is documented in §3. The review names this risk
+   (§18) but its mitigation ("define clear authority") is too weak given the evidence.
+   This needs a concrete rule set before Phase 5: GraphData that is a projection
+   target is **never** hand-authored; materialisation is driven by content hashes and
+   a `Materialization` record; staleness is detected, not assumed; and there is a
+   single code path that rebuilds a projection from assertions.
+
+4. **Identity reconciliation (§4.9) is a product, not a table.** Fuzzy matching plus a
+   human review queue plus agent-proposed matches is a significant surface with its
+   own UI, states, and failure modes. It is billed at roughly one phase alongside
+   provenance. It should be flagged as disproportionately expensive and, where
+   possible, deferred behind exact/alias matching (which the existing
+   `layer_aliases` pattern already models) until the slice in §17 proves it is
+   needed.
+
+5. **The semantic layer is a product bet on a new use case, and should be framed as
+   one.** The codebase's centre of gravity today is graph visualisation and code
+   analysis (`layercake-code-analysis`, `layercake-projections`, Mermaid/DOT/3D
+   export). Security-consulting knowledge modelling is a *new* direction. The review
+   presents typed records as the "long-term canonical" model as though it is the
+   obvious evolution of the current tool; it is better understood as a strategic
+   pivot that the §17 slice exists to de-risk. Existing graph/code-analysis data has
+   no clean semantic type and will live indefinitely under the "GraphData as
+   graph-native" escape hatch — so the semantic benefits accrue mostly to new
+   projects. That is fine, but it should be stated so expectations are set and so the
+   backfill cost of existing projects is not assumed away.
+
+### 4.3 Smaller points
+
+- The review lists `source_dataset_id` becoming `primary_source_dataset_id` for
+  compatibility (§4.3). Good — but note there are already two provenance-ish
+  mechanisms in play (`source_dataset_id` on rows and `source_dataset_id` on
+  `project_layers`); the migration to `ProvenanceLink` should reconcile both, not
+  just the row-level one.
+- `entities/mod.rs` still declares the legacy modules and a
+  `pub use dataset_nodes as datasets` backwards-compat alias (`:45`). These are cheap
+  Phase 0 deletions once callers are removed and are a good "is the cutover actually
+  done?" tripwire.
+- The review is silent on `graph_edits` replay semantics under the new model. Since
+  §12.2 wants manual edits represented as assertions/overrides rather than
+  mutations, the existing edit-replay machinery (`graph_edit_service`,
+  `graph_edits`) needs an explicit place in the target model or an explicit
+  deprecation.
+
+---
+
+## 5. Recommended adjustments to the roadmap
+
+1. **Harden Phase 0 into a verified gate.** Remove all references to dropped tables
+   (`data_set_service` preview paths, `merge_builder` legacy fallback,
+   `graph_edit_service` else-branch, GraphQL legacy mappers), drop the legacy entity
+   modules, and add "no legacy read" telemetry and DB constraints *before*
+   proceeding. Treat the July 2026 `graph_edits` FK breakage as the motivating
+   incident.
+
+2. **Reorder around the §17 vertical slice.** Deliver control-ownership (records →
+   assertions → one dimension set → AnalysisFrame → graph + matrix projectors →
+   shared theme → explain-to-source) as the first semantic increment, on a small
+   fixed set of types, before generalising any single layer horizontally.
+
+3. **Write the materialisation contract before assertions exist.** Decide and
+   document authority, staleness detection, and the single rebuild path for
+   projections, so the assertion/GraphData split does not recreate the dual-write
+   problem.
+
+4. **Record the ADRs the review calls for (§16), plus one it omits:** an explicit
+   decision that Layercake is committing to a consulting knowledge-modelling
+   product, with the §17 slice as the go/no-go checkpoint. The other seven decisions
+   are well chosen and should be recorded as written.
+
+5. **Keep the escape hatch explicit.** Existing graph and code-analysis data remains
+   pure GraphData with no semantic type; the semantic layer is additive and opt-in
+   per project. This bounds migration cost and lets the two use cases coexist.
+
+---
+
+## 6. Overall
+
+The review is accurate, well-structured, and points at a real and defensible target
+architecture. Its weaknesses are not in the destination but in the trip: it
+under-weights that the *previous* unification is still unfinished (with live reads
+against dropped tables and a breakage fixed only this month), it presents a
+horizontal roadmap that its own §17 contradicts, and it re-introduces a dual-write
+hazard without a hard mitigation. Adopt the direction; finish and *prove* Phase 0
+first; then validate the whole stack with the single vertical slice before building
+any layer out broadly.

--- a/reviews/20260710-data-model-direction-roadmap.md
+++ b/reviews/20260710-data-model-direction-roadmap.md
@@ -5,6 +5,22 @@
 **Scope:** Data model, semantic foundation, analysis products, presentation layers, UI, CLI, MCP, and agentic access  
 **Repository:** `michiel/layercake-tool`
 
+**Related documents:**
+
+- `reviews/20260710-data-model-direction-assessment.md` — independent validation of
+  this review's factual claims and a critique of its sequencing and risk weighting.
+- `plans/20260710-phase0-graph-data-cutover.md` — the detailed implementation plan
+  for Phase 0 below.
+
+> **Update (2026-07-10):** An independent code validation confirmed every structural
+> claim in this review and established that **Phase 0 is not merely stabilisation —
+> the previous single-schema cutover is genuinely unfinished**. Live services still
+> read tables that migrations have already dropped, and a silent breakage from the
+> same incomplete drop was fixed only this month
+> (`m20260709_000001_rebuild_graph_edits_drop_graphs_fk`). Phase 0 has therefore been
+> promoted to a **hard, verified gate** ahead of any semantic expansion, and its
+> scope is enumerated concretely in the linked plan. See §15 Phase 0 for the evidence.
+
 ---
 
 ## Executive summary
@@ -1583,6 +1599,33 @@ Adopt the following as explicit design rules:
 
 ## Phase 0 — Complete and stabilise the current graph foundation
 
+> **This phase is a verified gate, not a formality.** Code validation on 2026-07-10
+> found that the legacy tables were already dropped by
+> `m20251215_000001_drop_legacy_graph_tables`, yet live code still references them:
+>
+> - `services/data_set_service.rs` reads `dataset_graph_nodes` / `dataset_graph_edges`
+>   / `dataset_graph_layers` in `get_graph_summary` and `get_graph_page` — both
+>   reachable from GraphQL (`graphql/queries/mod.rs:109,127`) — and deletes them in
+>   `update_graph_data`;
+> - `pipeline/dag_executor.rs`, `pipeline/merge_builder.rs`, and
+>   `services/graph_service.rs` retain "fall back to legacy `graphs` table" branches,
+>   and `dag_executor` builds an in-memory `graphs::Model` purely for hash input;
+> - `app_context/graph_operations.rs` and `services/import_service.rs` write and read
+>   the dropped `graph_layers` / `graph_nodes` tables (layers now live in
+>   `project_layers`);
+> - `services/graph_edit_service.rs` has an `else` branch that loads/updates the
+>   dropped `graphs` table;
+> - GraphQL (`graphql/types/graph.rs`, `graph_node.rs`, `graph_edge.rs`, `preview.rs`)
+>   still maps from `graphs::Model` / `graph_nodes::Model` / `graph_edges::Model`;
+> - `database/entities/mod.rs` still declares the legacy entity modules and a
+>   `pub use dataset_nodes as datasets` compatibility alias.
+>
+> `m20260709_000001_rebuild_graph_edits_drop_graphs_fk` (this month) documents the
+> concrete failure mode: an incomplete drop left a dangling foreign key that
+> "silently breaks the entire graph-edit tracking / replay feature." The full
+> enumeration and step-by-step remediation are in
+> `plans/20260710-phase0-graph-data-cutover.md`.
+
 ### Objectives
 
 - finish the single-schema migration;
@@ -1605,7 +1648,9 @@ Adopt the following as explicit design rules:
 
 - one authoritative graph persistence path;
 - no dual writes;
-- no hidden legacy reads;
+- no hidden legacy reads (verified: no source reference to `graphs`, `graph_nodes`,
+  `graph_edges`, `graph_layers`, or `dataset_graph_*` outside migrations);
+- the legacy entity modules are deleted;
 - all graph operations use the same service layer.
 
 ---


### PR DESCRIPTION
## Summary

Documentation-only PR that validates the data model direction review against the code and turns its Phase 0 into an actionable, verified plan.

- **`reviews/20260710-data-model-direction-assessment.md`** (new) — independent validation of the direction review. All structural claims about the current schema were checked against the entities/migrations and confirmed. Key finding: the graph_data single-schema cutover is genuinely unfinished — live services still read tables that `m20251215_000001_drop_legacy_graph_tables` has already dropped, and `m20260709_000001_rebuild_graph_edits_drop_graphs_fk` (this month) fixed a silent breakage from the same incomplete drop. Also critiques the roadmap's sequencing (invert around the §17 vertical slice), a re-introduced dual-write hazard, and scope.
- **`reviews/20260710-data-model-direction-roadmap.md`** (updated) — promotes Phase 0 from stabilisation to a hard, verified gate, with the concrete evidence and cross-references.
- **`plans/20260710-phase0-graph-data-cutover.md`** (new) — detailed Phase 0 implementation plan: full inventory of legacy references across 12 source files, the authoritative replacement for each dropped table, seven workstreams, a verification method (grep guard + targeted build/test), a progress tracker, and exit criteria.

## Evidence that Phase 0 is a gate

- `graphql/queries/mod.rs:109,127` → `data_set_service::get_graph_summary`/`get_graph_page` → dropped `dataset_graph_*` (dataset preview broken).
- `pipeline/dag_executor.rs`, `pipeline/merge_builder.rs`, `services/graph_service.rs` → "fall back to legacy `graphs` table" branches.
- `app_context/graph_operations.rs`, `services/import_service.rs` → write/read dropped `graph_layers`/`graph_nodes`.
- `services/graph_edit_service.rs` → `else` branch against dropped `graphs`.
- `graphql/types/{graph,graph_node,graph_edge,preview}.rs` → map dropped `graphs`/`graph_nodes`/`graph_edges` models.

## Testing

Docs only — no code changes. Baseline `cargo build -p layercake-core -p layercake-server -p layercake-cli` is green (recorded in the plan). Implementation of the plan follows separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RbMwxFs3XArNyPT4BvP1Uh)_