### PR TITLE
feat(transforms): allow 0 for truncate node/edge label operations

### DIFF
--- a/frontend/src/components/editors/PlanVisualEditor/forms/TransformNodeConfigForm.tsx
+++ b/frontend/src/components/editors/PlanVisualEditor/forms/TransformNodeConfigForm.tsx
@@ -111,6 +111,7 @@ const transformsEqual = (a: GraphTransform[], b: GraphTransform[]): boolean =>
   JSON.stringify(a) === JSON.stringify(b);
 
 const isPositive = (value?: number) => typeof value === 'number' && value > 0;
+const isNonNegative = (value?: number) => typeof value === 'number' && value >= 0;
 
 const coerceTransformConfig = (raw: any): TransformNodeConfig => {
   if (raw && Array.isArray(raw.transforms)) {
@@ -168,11 +169,11 @@ const isTransformValid = (transform: GraphTransform): boolean => {
     case 'PartitionWidthLimit':
       return isPositive(transform.params.maxPartitionWidth);
     case 'NodeLabelMaxLength':
-      return isPositive(transform.params.nodeLabelMaxLength);
+      return isNonNegative(transform.params.nodeLabelMaxLength);
     case 'NodeLabelInsertNewlines':
       return isPositive(transform.params.nodeLabelInsertNewlinesAt);
     case 'EdgeLabelMaxLength':
-      return isPositive(transform.params.edgeLabelMaxLength);
+      return isNonNegative(transform.params.edgeLabelMaxLength);
     case 'EdgeLabelInsertNewlines':
       return isPositive(transform.params.edgeLabelInsertNewlinesAt);
     case 'InvertGraph':
@@ -362,7 +363,7 @@ export const TransformNodeConfigForm: React.FC<TransformNodeConfigFormProps> = (
             <Input
               id={`node-label-max-length-${index}`}
               type="number"
-              min={1}
+              min={0}
               max={200}
               value={transform.params.nodeLabelMaxLength ?? ''}
               onChange={e => {
@@ -402,7 +403,7 @@ export const TransformNodeConfigForm: React.FC<TransformNodeConfigFormProps> = (
             <Input
               id={`edge-label-max-length-${index}`}
               type="number"
-              min={1}
+              min={0}
               max={200}
               value={transform.params.edgeLabelMaxLength ?? ''}
               onChange={e => {

--- a/frontend/src/components/editors/PlanVisualEditor/nodes/TransformNode.tsx
+++ b/frontend/src/components/editors/PlanVisualEditor/nodes/TransformNode.tsx
@@ -37,11 +37,11 @@ const formatTransform = (transform: GraphTransform): string | null => {
     case 'PartitionWidthLimit':
       return params.maxPartitionWidth ? `Width ≤ ${params.maxPartitionWidth}` : FRIENDLY_NAMES[kind]
     case 'NodeLabelMaxLength':
-      return params.nodeLabelMaxLength ? `Node labels ≤ ${params.nodeLabelMaxLength}` : FRIENDLY_NAMES[kind]
+      return params.nodeLabelMaxLength != null ? `Node labels ≤ ${params.nodeLabelMaxLength}` : FRIENDLY_NAMES[kind]
     case 'NodeLabelInsertNewlines':
       return params.nodeLabelInsertNewlinesAt ? `Wrap node labels @ ${params.nodeLabelInsertNewlinesAt}` : FRIENDLY_NAMES[kind]
     case 'EdgeLabelMaxLength':
-      return params.edgeLabelMaxLength ? `Edge labels ≤ ${params.edgeLabelMaxLength}` : FRIENDLY_NAMES[kind]
+      return params.edgeLabelMaxLength != null ? `Edge labels ≤ ${params.edgeLabelMaxLength}` : FRIENDLY_NAMES[kind]
     case 'EdgeLabelInsertNewlines':
       return params.edgeLabelInsertNewlinesAt ? `Wrap edge labels @ ${params.edgeLabelInsertNewlinesAt}` : FRIENDLY_NAMES[kind]
     case 'InvertGraph':

--- a/layercake-core/src/plan_dag/transforms.rs
+++ b/layercake-core/src/plan_dag/transforms.rs
@@ -195,9 +195,6 @@ impl GraphTransform {
                 let length = self.params.node_label_max_length.ok_or_else(|| {
                     anyhow!("NodeLabelMaxLength transform requires node_label_max_length")
                 })?;
-                if length == 0 {
-                    return Err(anyhow!("node_label_max_length must be greater than zero"));
-                }
                 graph.truncate_node_labels(length);
                 Some(format!(
                     "### Transform: Node Label Max Length\n- Max length: {}\n- Nodes after: {}",
@@ -227,9 +224,6 @@ impl GraphTransform {
                 let length = self.params.edge_label_max_length.ok_or_else(|| {
                     anyhow!("EdgeLabelMaxLength transform requires edge_label_max_length")
                 })?;
-                if length == 0 {
-                    return Err(anyhow!("edge_label_max_length must be greater than zero"));
-                }
                 graph.truncate_edge_labels(length);
                 Some(format!(
                     "### Transform: Edge Label Max Length\n- Max length: {}\n- Edges after: {}",

--- a/layercake-server/src/graphql/types/plan_dag/transforms.rs
+++ b/layercake-server/src/graphql/types/plan_dag/transforms.rs
@@ -199,9 +199,6 @@ impl GraphTransform {
                 let length = self.params.node_label_max_length.ok_or_else(|| {
                     anyhow!("NodeLabelMaxLength transform requires node_label_max_length")
                 })?;
-                if length == 0 {
-                    return Err(anyhow!("node_label_max_length must be greater than zero"));
-                }
                 graph.truncate_node_labels(length);
                 Some(format!(
                     "### Transform: Node Label Max Length\n- Max length: {}\n- Nodes after: {}",
@@ -231,9 +228,6 @@ impl GraphTransform {
                 let length = self.params.edge_label_max_length.ok_or_else(|| {
                     anyhow!("EdgeLabelMaxLength transform requires edge_label_max_length")
                 })?;
-                if length == 0 {
-                    return Err(anyhow!("edge_label_max_length must be greater than zero"));
-                }
                 graph.truncate_edge_labels(length);
                 Some(format!(
                     "### Transform: Edge Label Max Length\n- Max length: {}\n- Edges after: {}",


### PR DESCRIPTION
## Summary

Allow a max-length of **0** for the **Truncate Node Labels** and **Truncate Edge Labels** transforms, which empties the label string. Previously both the core and GraphQL transform paths rejected 0, and the UI blocked it via positive-only validation and `min={1}` inputs.

## Changes

- Remove the `length == 0` guards in the DAG transform executors (core and server copies).
- UI: validate the two max-length fields as non-negative (new `isNonNegative` helper) and set `min={0}`.
- Fix `TransformNode` preview so a value of `0` renders `... labels ≤ 0` instead of falling back to the generic name (was a truthy check that treated `0` as unset).

## Scope notes

- The `*InsertNewlines` transforms still require `> 0` (a wrap-column of 0 is meaningless).
- The legacy YAML `GraphConfig` path (`plan_execution.rs`) still uses `> 0` as an "is this transform configured" sentinel and is intentionally left unchanged.

## Testing

- `cargo build -p layercake-core -p layercake-server` — passes.
- `tsc --noEmit` on the frontend — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)