### PR TITLE
Sequence render settings + PlantUML colours + newline parse-error fix

### DIFF
--- a/frontend/src/components/stories/StorySequencesEditor.tsx
+++ b/frontend/src/components/stories/StorySequencesEditor.tsx
@@ -11,7 +11,9 @@ import {
   IconX,
   IconGripVertical,
   IconArrowNarrowRight,
+  IconSettings,
 } from '@tabler/icons-react'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { Group, Stack } from '@/components/layout-primitives'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -32,6 +34,10 @@ import {
 import { GET_DATASOURCES, DataSet } from '@/graphql/datasets'
 import { SequenceDiagramDialog } from '@/components/stories/SequenceDiagramDialog'
 import { GET_PROJECT_LAYERS, ProjectLayer } from '@/graphql/layers'
+import { GET_PLAN_DAG } from '@/graphql/plan-dag'
+import { NodeConfigDialog } from '@/components/editors/PlanVisualEditor/NodeConfigDialog'
+import { PlanDagNodeType } from '@/types/plan-dag'
+import { UPDATE_PLAN_DAG_NODE } from '@/graphql/plan-dag'
 
 type GraphEdge = { id: string; source: string; target: string; label?: string; comments?: string }
 type GraphNode = { id: string; label?: string; name?: string; layer?: string }
@@ -86,6 +92,50 @@ export const StorySequencesEditor = ({
     skip: !projectId,
   })
   const projectLayers: ProjectLayer[] = (layersData as any)?.projectLayers || []
+
+  // Resolve the SequenceArtefactNode downstream of this story's StoryNode so the
+  // "edit properties" (render settings) button can edit its config — the same
+  // form used by the artefacts page.
+  const { data: planDagData, refetch: refetchPlanDag } = useQuery(GET_PLAN_DAG, {
+    variables: { projectId, planId: null },
+    skip: !projectId,
+  })
+  const sequenceArtefactNode = useMemo(() => {
+    const dag = (planDagData as any)?.getPlanDag
+    if (!dag) return null
+    const nodes: any[] = dag.nodes ?? []
+    const edges: any[] = dag.edges ?? []
+    const parse = (c: any) => {
+      try { return typeof c === 'string' ? JSON.parse(c) : (c ?? {}) } catch { return {} }
+    }
+    // Find the StoryNode bound to this story entity.
+    const storyNode = nodes.find(
+      (n) => n.nodeType === 'StoryNode' && parse(n.config).storyId === storyId
+    )
+    if (!storyNode) return null
+    // Its downstream SequenceArtefactNode(s). Use the first if several exist.
+    const downstreamIds = edges.filter((e) => e.source === storyNode.id).map((e) => e.target)
+    return (
+      nodes.find(
+        (n) => n.nodeType === 'SequenceArtefactNode' && downstreamIds.includes(n.id)
+      ) ?? null
+    )
+  }, [planDagData, storyId])
+
+  const [renderSettingsOpen, setRenderSettingsOpen] = useState(false)
+  const [updatePlanDagNode] = useMutation(UPDATE_PLAN_DAG_NODE)
+  const handleSaveRenderSettings = async (nodeId: string, config: any, metadata: any) => {
+    await updatePlanDagNode({
+      variables: {
+        projectId,
+        planId: null,
+        nodeId,
+        updates: { config: JSON.stringify(config), metadata },
+      },
+    })
+    setRenderSettingsOpen(false)
+    await refetchPlanDag()
+  }
 
   const datasetGraphs = useMemo(() => {
     const map = new Map<number, { graph: GraphData; json: string; name: string }>()
@@ -420,10 +470,34 @@ export const StorySequencesEditor = ({
         <CardHeader>
           <Group justify="between" align="center">
             <CardTitle className="text-base">Sequences</CardTitle>
-            <Button size="sm" onClick={handleAddSequence} disabled={sequencesLoading || datasetsLoading}>
-              <IconPlus className="mr-2 h-4 w-4" />
-              Add Section
-            </Button>
+            <Group gap="xs" align="center">
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        className="h-8 w-8"
+                        onClick={() => setRenderSettingsOpen(true)}
+                        disabled={!sequenceArtefactNode}
+                      >
+                        <IconSettings className="h-4 w-4" />
+                      </Button>
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {sequenceArtefactNode
+                      ? 'Edit render properties (target, contain nodes, layers)'
+                      : 'No sequence artefact node in the plan for this story yet'}
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+              <Button size="sm" onClick={handleAddSequence} disabled={sequencesLoading || datasetsLoading}>
+                <IconPlus className="mr-2 h-4 w-4" />
+                Add Section
+              </Button>
+            </Group>
           </Group>
         </CardHeader>
         <CardContent className="grid gap-3 md:grid-cols-3">
@@ -792,6 +866,27 @@ export const StorySequencesEditor = ({
         notePosition={edgeEditorPayload?.notePosition}
         onSave={handleEdgeEditSave}
       />
+      {sequenceArtefactNode && (
+        <NodeConfigDialog
+          opened={renderSettingsOpen}
+          onClose={() => setRenderSettingsOpen(false)}
+          nodeType={PlanDagNodeType.SEQUENCE_ARTEFACT}
+          projectId={projectId}
+          onSave={handleSaveRenderSettings}
+          nodeId={sequenceArtefactNode.id}
+          config={(() => {
+            try {
+              return typeof sequenceArtefactNode.config === 'string'
+                ? JSON.parse(sequenceArtefactNode.config)
+                : (sequenceArtefactNode.config ?? {})
+            } catch {
+              return {}
+            }
+          })()}
+          metadata={sequenceArtefactNode.metadata || {}}
+          storyIdHint={storyId}
+        />
+      )}
     </>
   )
 }

--- a/frontend/src/pages/ProjectArtefactsPage.tsx
+++ b/frontend/src/pages/ProjectArtefactsPage.tsx
@@ -87,6 +87,9 @@ type ArtefactEntry =
       config: Record<string, any>
       parentGraphId?: string
       parentStoryId?: string
+      // Story entity id (from the parent StoryNode's config) — used to populate
+      // the per-sequence list when editing a SequenceArtefactNode's properties.
+      storyId?: number
     }
 
 const parseConfig = (config?: string | null): Record<string, any> => {
@@ -195,6 +198,7 @@ const ProjectArtefactsPage: React.FC = () => {
     nodeType: PlanDagNodeType | null
     config: any
     metadata: any
+    storyId?: number
   }>({
     open: false,
     nodeId: null,
@@ -407,6 +411,7 @@ const [exportForPreview] = useMutation(EXPORT_NODE_OUTPUT, {
 
       storyChildren.forEach((childId) => traverseStory(childId, depth + 1))
 
+      const parentStoryEntityId = parseConfig(node.config).storyId as number | undefined
       sequenceChildren.forEach((child) => {
         storyEntries.push({
           type: 'artefact',
@@ -414,6 +419,7 @@ const [exportForPreview] = useMutation(EXPORT_NODE_OUTPUT, {
           depth: depth + 1,
           config: parseConfig(child.config),
           parentStoryId: nodeId,
+          storyId: parentStoryEntityId,
         })
       })
     }
@@ -457,12 +463,20 @@ const [exportForPreview] = useMutation(EXPORT_NODE_OUTPUT, {
     navigate(route)
   }
 
-  const handleEditNode = (nodeId: string, nodeType: string, config: any, metadata: any) => {
+  const handleEditNode = (
+    nodeId: string,
+    nodeType: string,
+    config: any,
+    metadata: any,
+    storyId?: number
+  ) => {
     let dagNodeType: PlanDagNodeType
     if (nodeType === 'GraphArtefactNode') {
       dagNodeType = PlanDagNodeType.GRAPH_ARTEFACT
     } else if (nodeType === 'TreeArtefactNode') {
       dagNodeType = PlanDagNodeType.TREE_ARTEFACT
+    } else if (nodeType === 'SequenceArtefactNode') {
+      dagNodeType = PlanDagNodeType.SEQUENCE_ARTEFACT
     } else if (nodeType === 'ProjectionNode') {
       dagNodeType = PlanDagNodeType.PROJECTION
     } else {
@@ -474,6 +488,7 @@ const [exportForPreview] = useMutation(EXPORT_NODE_OUTPUT, {
       nodeType: dagNodeType,
       config: parseConfig(config),
       metadata: metadata || {},
+      storyId,
     })
   }
 
@@ -814,7 +829,7 @@ const [exportForPreview] = useMutation(EXPORT_NODE_OUTPUT, {
                   size="icon"
                   variant="ghost"
                   className="h-8 w-8"
-                  onClick={() => handleEditNode(entry.node.id, entry.node.nodeType, entry.node.config, entry.node.metadata)}
+                  onClick={() => handleEditNode(entry.node.id, entry.node.nodeType, entry.node.config, entry.node.metadata, entry.type === 'artefact' ? entry.storyId : undefined)}
                 >
                   <IconSettings size={16} />
                 </Button>
@@ -1020,6 +1035,7 @@ const [exportForPreview] = useMutation(EXPORT_NODE_OUTPUT, {
           nodeId={editNodeDialog.nodeId}
           config={editNodeDialog.config}
           metadata={editNodeDialog.metadata}
+          storyIdHint={editNodeDialog.storyId}
         />
       )}
     </>

--- a/layercake-core/src/common/handlebars.rs
+++ b/layercake-core/src/common/handlebars.rs
@@ -46,6 +46,20 @@ pub fn get_handlebars() -> Handlebars<'static> {
     handlebars_helper!(stringeq: |s1: String, s2: String| s1.eq(&s2));
     handlebars.register_helper("stringeq", Box::new(stringeq));
 
+    // Collapse newlines and runs of whitespace into single spaces. Line-based
+    // diagram grammars (Mermaid/PlantUML sequence) treat a raw newline inside a
+    // label/note as a statement break, so free-text labels containing newlines
+    // otherwise produce "Expecting ..., got 'NEWLINE'" parse errors.
+    handlebars_helper!(inline: |v: Value| {
+        let s = match v {
+            Value::String(s) => s,
+            Value::Null => String::new(),
+            other => other.to_string(),
+        };
+        s.split_whitespace().collect::<Vec<_>>().join(" ")
+    });
+    handlebars.register_helper("inline", Box::new(inline));
+
     handlebars_helper!(is_empty: |v: Value| {
         match v {
             serde_json::Value::Array(arr) => arr.is_empty(),

--- a/layercake-core/src/export/sequence_renderer.rs
+++ b/layercake-core/src/export/sequence_renderer.rs
@@ -163,3 +163,75 @@ pub fn render_sequence_template(
     let rendered = handlebars.render_template(template, &payload)?;
     Ok(rendered)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::export::{to_mermaid_sequence, to_plantuml_sequence};
+
+    fn participant(alias: &str, label: &str, color: Option<&str>) -> SequenceParticipant {
+        SequenceParticipant {
+            alias: alias.into(),
+            id: alias.into(),
+            label: label.into(),
+            dataset_id: 1,
+            dataset_name: "d".into(),
+            layer_color: color.map(|c| c.into()),
+            ..Default::default()
+        }
+    }
+
+    fn context_with_newlines() -> SequenceRenderContext {
+        let mut ctx = SequenceRenderContext::default();
+        ctx.config.show_notes = true;
+        let a = participant("a", "Alice", Some("#ff0000"));
+        // Labels/notes with embedded newlines used to break the line-based grammars.
+        let b = participant("b", "Bob\nsecond", Some("#00aaff"));
+        ctx.participant_groups = vec![SequenceParticipantGroup {
+            id: "g1".into(),
+            label: "Group\nOne".into(),
+            color: Some("#00ff00".into()),
+            participants: vec![a.clone(), b.clone()],
+        }];
+        ctx.participants = vec![a, b];
+        ctx.first_participant_alias = Some("a".into());
+        ctx.last_participant_alias = Some("b".into());
+        ctx.sequences = vec![SequenceRender {
+            id: 1,
+            name: "Seq\n1".into(),
+            description: None,
+            steps: vec![SequenceStep {
+                id: "s".into(),
+                dataset_id: 1,
+                dataset_name: "d".into(),
+                source: SequenceParticipantRef { alias: "a".into(), label: "Alice".into() },
+                target: SequenceParticipantRef { alias: "b".into(), label: "Bob".into() },
+                label: "line1\nline2".into(),
+                note: Some("note\nwrapped".into()),
+                note_position: Some("both".into()),
+            }],
+        }];
+        ctx
+    }
+
+    #[test]
+    fn newlines_do_not_break_mermaid() {
+        let out = to_mermaid_sequence::render(&context_with_newlines()).unwrap();
+        // A statement line must never be split by a raw newline from free text.
+        assert!(out.contains(r#"participant b as "Bob second""#), "{out}");
+        assert!(out.contains("a->>b: line1 line2"), "{out}");
+        assert!(out.contains("Note over a,b: note wrapped"), "{out}");
+        assert!(!out.contains("line1\nline2"));
+    }
+
+    #[test]
+    fn newlines_do_not_break_plantuml_and_participants_are_coloured() {
+        let out = to_plantuml_sequence::render(&context_with_newlines()).unwrap();
+        assert!(out.contains("a -> b : line1 line2"), "{out}");
+        // Per-participant layer colours (PlantUML capability; Mermaid has none).
+        assert!(out.contains(r#"participant a as "Alice" #ff0000"#), "{out}");
+        assert!(out.contains(r#"participant b as "Bob second" #00aaff"#), "{out}");
+        // Partition box grouping with layer colour.
+        assert!(out.contains(r#"box "Group One" #00ff00"#), "{out}");
+    }
+}

--- a/layercake-core/src/export/to_mermaid_sequence.hbs
+++ b/layercake-core/src/export/to_mermaid_sequence.hbs
@@ -5,37 +5,37 @@ sequenceDiagram
 
 {{#unless (is_empty sequence.participantGroups)}}
   {{#each sequence.participantGroups}}
-box {{#if this.color}}{{this.color}}{{/if}} "{{this.label}}"
+box {{#if this.color}}{{this.color}}{{/if}} "{{inline this.label}}"
     {{#each this.participants}}
-    participant {{alias}} as "{{label}}"
+    participant {{alias}} as "{{inline label}}"
     {{/each}}
 end
   {{/each}}
 {{else}}
   {{#each sequence.participants}}
-  participant {{alias}} as "{{label}}"
+  participant {{alias}} as "{{inline label}}"
   {{/each}}
 {{/unless}}
 
 {{#unless (is_empty sequence.sequences)}}
   {{#each sequence.sequences}}
-%% Sequence: {{name}}
+%% Sequence: {{inline name}}
     {{#if @root.sequence.firstParticipantAlias}}
-    Note over {{@root.sequence.firstParticipantAlias}},{{@root.sequence.lastParticipantAlias}}: {{name}}
+    Note over {{@root.sequence.firstParticipantAlias}},{{@root.sequence.lastParticipantAlias}}: {{inline name}}
     {{/if}}
     {{#each steps}}
       {{#if @root.sequence.config.showNotes}}
         {{#if note}}
           {{#if (stringeq notePosition "source")}}
-    Note over {{source.alias}}: {{note}}
+    Note over {{source.alias}}: {{inline note}}
           {{else if (stringeq notePosition "target")}}
-    Note over {{target.alias}}: {{note}}
+    Note over {{target.alias}}: {{inline note}}
           {{else}}
-    Note over {{source.alias}},{{target.alias}}: {{note}}
+    Note over {{source.alias}},{{target.alias}}: {{inline note}}
           {{/if}}
         {{/if}}
       {{/if}}
-    {{source.alias}}->>{{target.alias}}: {{label}}
+    {{source.alias}}->>{{target.alias}}: {{inline label}}
     {{/each}}
   {{/each}}
 {{else}}

--- a/layercake-core/src/export/to_plantuml_sequence.hbs
+++ b/layercake-core/src/export/to_plantuml_sequence.hbs
@@ -5,40 +5,40 @@
 
 {{#unless (is_empty sequence.participantGroups)}}
   {{#each sequence.participantGroups}}
-box "{{this.label}}" {{#if this.color}}{{this.color}}{{/if}}
+box "{{inline this.label}}" {{#if this.color}}{{this.color}}{{/if}}
   {{#each this.participants}}
-  participant {{alias}} as "{{label}}"
+  participant {{alias}} as "{{inline label}}"{{#if layerColor}} {{layerColor}}{{/if}}
   {{/each}}
 end box
   {{/each}}
 {{else}}
   {{#each sequence.participants}}
-participant {{alias}} as "{{label}}"
+participant {{alias}} as "{{inline label}}"{{#if layerColor}} {{layerColor}}{{/if}}
   {{/each}}
 {{/unless}}
 
 {{#unless (is_empty sequence.sequences)}}
   {{#each sequence.sequences}}
-== {{name}} ==
+== {{inline name}} ==
     {{#each steps}}
       {{#if @root.sequence.config.showNotes}}
         {{#if note}}
           {{#if (stringeq notePosition "source")}}
 note over {{source.alias}}
-{{note}}
+{{inline note}}
 end note
           {{else if (stringeq notePosition "target")}}
 note over {{target.alias}}
-{{note}}
+{{inline note}}
 end note
           {{else}}
 note over {{source.alias}},{{target.alias}}
-{{note}}
+{{inline note}}
 end note
           {{/if}}
         {{/if}}
       {{/if}}
-{{source.alias}} -> {{target.alias}} : {{label}}
+{{source.alias}} -> {{target.alias}} : {{inline label}}
     {{/each}}
   {{/each}}
 {{else}}


### PR DESCRIPTION
## Summary

Fixes the Mermaid sequence parse error, adds PlantUML per-participant layer colours, fixes the artefacts settings-button bug for sequences, and adds a story-level render-settings button on the sequences tab.

## 1. Mermaid "Expecting …, got 'NEWLINE'" — fixed
Reproduced: the backend sequence templates emitted free-text labels/notes verbatim, so any label/note containing a newline split a statement across lines. Added an `inline` Handlebars helper (collapses whitespace/newlines to single spaces) applied to every participant label, group label, message label, note, and sequence name in **both** Mermaid and PlantUML templates. Regression-tested.

## 2. PlantUML participant layer colours
`participant X as "Y" #color` using the already-populated `SequenceParticipant.layer_color`. Mermaid has no per-participant colour capability, so it keeps colouring only the partition box.

## 3. Partition boxes (contain nodes)
Already worked in both templates (`box "label" #color … end box` when `containNodes` groups participants by partition). Confirmed + covered by the new tests — no change needed beyond verification.

## 4. Artefacts settings button opened "tree options" — fixed
The gear button routed `SequenceArtefactNode` through the else-fallback to `TREE_ARTEFACT`, opening the Tree Artefact form. Added the missing `SequenceArtefactNode → SEQUENCE_ARTEFACT` branch so it opens `SequenceArtefactNodeConfigForm`, and pass `storyIdHint` (from the parent StoryNode's `config.storyId`) so the per-sequence list populates.

## 5. Story-level render-settings button (sequences tab)
One gear in the sequences-tab header (not per row) that resolves the `SequenceArtefactNode` downstream of the story's StoryNode and opens the same `NodeConfigDialog` (render target mermaid/plantuml, contain nodes, layers) — consistent with the artefacts page. Disabled with a tooltip when the story has no sequence artefact node in the plan yet.

## Verification
- `cargo build --workspace` clean; new `sequence_renderer` tests pass (newlines don't break either grammar; PlantUML participants carry colours + box grouping).
- `tsc --noEmit` clean; frontend production build succeeds.
- ⚠️ No live-browser click-through (no Chrome in this env) — the two UI changes are verified via typecheck + build; the backend rendering is verified via real rendered output + tests.

## Notes
- The tab's eye-icon preview (`SequenceDiagramDialog`) renders Mermaid client-side and already strips newlines, so the parse error was the backend export path (fixed here).
- If a story has multiple sequence artefact nodes, the resolver uses the first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)