### PR TITLE
Tool-review-001 uplift: fix blocking sequence bugs + agent-facing improvements

### DIFF
--- a/docs-tool/command/doc.md
+++ b/docs-tool/command/doc.md
@@ -20,6 +20,8 @@ layercake doc workflow edit-a-plan
 layercake doc command schema
 layercake doc guide agent              # the AI agent query-interface guide
 layercake doc guide model              # the graph model documentation
+layercake doc guide node-types         # every plan DAG node type + its config
+layercake doc guide graph-json         # the GraphJson schema for datasets
 ```
 
 ## For agents

--- a/docs-tool/command/doctor.md
+++ b/docs-tool/command/doctor.md
@@ -1,0 +1,35 @@
+# Command: `layercake doctor`
+
+Scan a project for structural health problems — the classes of issue that
+otherwise only surface as a silently empty diagram or a stale computed graph.
+
+## Usage
+
+```bash
+layercake doctor --project 36                 # human-readable report
+layercake doctor --project 36 --json          # machine-readable
+layercake doctor --project 36 --database ./my.db
+```
+
+Exits non-zero if any **error**-severity finding is present (so CI/scripts can
+gate on it).
+
+## Checks
+
+- **node-missing-dataset** (error) — a plan DAG node's `config.dataSetId` points
+  at a dataset that no longer exists.
+- **orphaned-computed-graph** (warning) — a computed `graph_data` row whose
+  originating DAG node is gone.
+- **empty-sequence-context** / **sequence-context-warning** (warning) — a
+  persisted sequence context with no participants, or carrying build warnings.
+- **story-sequence-unresolved** (warning) — a story sequence references an edge
+  that doesn't resolve against its enabled datasets.
+- **story-empty** (error) — a story has sequences but resolves to zero
+  participants (its diagram will be blank).
+- **story-build-failed** (error) — the story context builder errored.
+
+## For agents
+
+Run this first when a diagram renders empty or a graph looks stale. It
+operationalises the manual diagnosis (inspecting `sequences[0].steps.length`,
+matching hash ids to datasets, hunting orphaned graphs) into one command.

--- a/docs-tool/guide/graph-json.md
+++ b/docs-tool/guide/graph-json.md
@@ -1,0 +1,66 @@
+# Guide: GraphJson schema
+
+`updateDataSetGraphData` and a dataset's `graphJson` field use this JSON shape.
+Fields marked **required** must be present or the call fails (e.g.
+`missing field weight`, `missing field layers`).
+
+```json
+{
+  "nodes": [ { …Node } ],
+  "edges": [ { …Edge } ],
+  "layers": [ { …Layer } ]
+}
+```
+
+`nodes`, `edges`, and `layers` are all **required** array keys (use `[]` if empty).
+
+## Node
+
+| field | type | required | notes |
+|-------|------|----------|-------|
+| `id` | string | **yes** | unique within the dataset |
+| `label` | string | **yes** | display label |
+| `layer` | string | **yes** | layer id (should exist in `layers`) |
+| `weight` | int | **yes** | 1 is a sensible default |
+| `is_partition` | bool | no (default false) | partition/container node |
+| `belongs_to` | string\|null | no | parent partition id |
+| `comment` | string\|null | no | surfaced in some renders |
+| `dataset` | int | no | source dataset id |
+| `attributes` | object | no | free-form |
+
+## Edge
+
+| field | type | required | notes |
+|-------|------|----------|-------|
+| `id` | string | **yes** | unique; stories reference edges by this id |
+| `source` | string | **yes** | node id |
+| `target` | string | **yes** | node id |
+| `label` | string | **yes** | message/edge label |
+| `weight` | int | **yes** | |
+| `layer` | string | **yes** | |
+| `comment` | string\|null | no | appended to sequence messages as `label: comment` |
+| `dataset` | int | no | |
+| `attributes` | object | no | |
+
+**Give every edge a stable `id`.** Stories store `edgeId` references; an edge
+without an `id` is keyed by `source:target` and is fragile to reorder.
+
+## Layer
+
+| field | type | required | notes |
+|-------|------|----------|-------|
+| `id` | string | **yes** | |
+| `label` | string | **yes** | |
+| `background_color` | string | no (defaulted) | hex, no leading `#` |
+| `text_color` | string | no (defaulted) | |
+| `border_color` | string | no (defaulted) | |
+| `alias` | string | no | |
+
+## Tip
+
+Dump an existing dataset to see a live example:
+
+```bash
+layercake api call --query 'query($id:Int!){ dataSet(id:$id){ graphJson } }' \
+  --variables '{"id": 199}'
+```

--- a/docs-tool/guide/node-types.md
+++ b/docs-tool/guide/node-types.md
@@ -1,0 +1,56 @@
+# Guide: Plan DAG node types
+
+A plan DAG is a directed graph of nodes. Each node has a `nodeType`, an opaque
+hash `id` (e.g. `dataset_766f8bef…`), a `metadata { label description }`, and a
+`config` (a JSON string). Data flows along edges from sources → transforms →
+artefacts.
+
+Inspect the exact config input for any type with:
+
+```bash
+layercake schema dump | grep -A15 "input <Type>ConfigInput"
+# e.g. input SequenceArtefactNodeConfigInput
+```
+
+To join a node back to its dataset PK, read `PlanDagNode.linkedDataSetId`
+(computed from `config.dataSetId`) rather than parsing config by hand.
+
+## The 10 node types
+
+### Source nodes
+
+- **DataSetNode** — brings a dataset's graph into the plan. `config.dataSetId`
+  links to the dataset PK. Deleting the node does NOT delete the dataset.
+- **GraphNode** — a computed graph produced by upstream processing; the unit
+  that gets executed into `graph_data`.
+
+### Transform / combine nodes
+
+- **TransformNode** — applies graph transforms (see `config`).
+- **FilterNode** — filters nodes/edges by criteria.
+- **MergeNode** — merges multiple upstream graphs into one.
+
+### Artefact (output) nodes — render during export, not eager execution
+
+- **GraphArtefactNode** — renders a graph to an output (e.g. Mermaid/PlantUML/
+  DOT). `config.renderTarget`, `config.outputPath`, `config.renderConfig`.
+- **TreeArtefactNode** — renders a hierarchy/tree output.
+- **ProjectionNode** — a projection artefact.
+
+### Story / sequence nodes
+
+- **StoryNode** — references a Story entity (`config.storyId`). On execution it
+  builds the story's sequence context. **Important:** the context builder uses
+  the Story's `enabledDatasetIds` from the DB, not the DAG upstream — see
+  `layercake doc workflow develop-a-story`. Wire DataSetNodes upstream of it.
+- **SequenceArtefactNode** — renders the story's sequences to a Mermaid or
+  PlantUML sequence diagram. Must be connected downstream of a StoryNode.
+  Config: `renderTarget` (`MermaidSequence`|`PlantUmlSequence`), `outputPath`,
+  `useStoryLayers`, and `renderConfig` (see the render-config guide).
+
+## Editing plan DAG nodes
+
+- Node `id`s are user-choosable and idempotent in `updatePlanDag` (pass your own
+  string id and the server keeps it). Edges without ids get `edge_XXXX`.
+- `metadata` needs a subfield selection when queried: `metadata { label description }`.
+- See `layercake doc workflow edit-a-plan` for the read-modify-write loop.

--- a/docs-tool/workflow/edit-a-plan.md
+++ b/docs-tool/workflow/edit-a-plan.md
@@ -67,4 +67,13 @@ you stop it (Ctrl-C). See `layercake doc workflow join-as-collaborator`.
   no server. Use `api call` when a server is up and you want live UI updates.
 - Mutations broadcast deltas to connected browsers automatically — no extra step
   is needed for the edit to appear live.
+- **`metadata` needs a subfield selection**: query it as `metadata { label description }`
+  and write it as `{ label description }`. A bare `metadata` errors with the
+  generic GraphQL "must have a selection of subfields".
+- Node **`id`s are user-choosable and idempotent** — pass your own string id and
+  the server keeps it. Edges without ids get generated `edge_XXXX` ids.
+- To join a node to its dataset PK, read `PlanDagNode.linkedDataSetId` rather than
+  parsing `config` by hand.
+- Node types, their config, and io: `layercake doc guide node-types`. The
+  `graphJson` shape: `layercake doc guide graph-json`.
 - Full API surface: `layercake schema dump`. Endpoints/headers: `layercake api info`.

--- a/layercake-cli/src/doctor.rs
+++ b/layercake-cli/src/doctor.rs
@@ -1,0 +1,39 @@
+//! `layercake doctor` — scan a project for structural health problems.
+
+use anyhow::Result;
+use layercake_core::database::connection::{establish_connection, get_database_url};
+use layercake_core::doctor::{run_diagnostics, Severity};
+
+pub async fn run(project: i32, database: Option<&str>, json: bool) -> Result<()> {
+    let db = establish_connection(&get_database_url(database)).await?;
+    let report = run_diagnostics(&db, project).await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+        return finish(report.error_count());
+    }
+
+    if report.is_healthy() {
+        println!("✓ project {}: no problems found", project);
+        return Ok(());
+    }
+
+    println!("Project {} — {} finding(s):\n", project, report.findings.len());
+    for f in &report.findings {
+        let tag = match f.severity {
+            Severity::Error => "ERROR",
+            Severity::Warning => "WARN ",
+            Severity::Info => "INFO ",
+        };
+        println!("  [{}] {}: {}", tag, f.check, f.message);
+    }
+    finish(report.error_count())
+}
+
+fn finish(error_count: usize) -> Result<()> {
+    if error_count > 0 {
+        // Non-zero exit so scripts/CI can gate on it.
+        std::process::exit(1);
+    }
+    Ok(())
+}

--- a/layercake-cli/src/main.rs
+++ b/layercake-cli/src/main.rs
@@ -13,6 +13,7 @@ mod console;
 mod api;
 mod db_info;
 mod doc;
+mod doctor;
 mod query;
 mod query_payloads;
 mod schema_dump;
@@ -108,6 +109,17 @@ enum Commands {
     Api {
         #[clap(subcommand)]
         command: ApiCommands,
+    },
+    /// Scan a project for structural health problems
+    Doctor {
+        /// Project id to scan
+        #[clap(long)]
+        project: i32,
+        #[clap(short, long, default_value = "layercake.db")]
+        database: String,
+        /// Emit machine-readable JSON
+        #[clap(long)]
+        json: bool,
     },
 }
 
@@ -318,6 +330,13 @@ async fn main() -> Result<()> {
         Commands::Schema { command } => match command {
             SchemaCommands::Dump { json } => schema_dump::dump(json).await?,
         },
+        Commands::Doctor {
+            project,
+            database,
+            json,
+        } => {
+            doctor::run(project, Some(&database), json).await?;
+        }
         Commands::Api { command } => match command {
             ApiCommands::Info {
                 url,

--- a/layercake-core/src/common/handlebars.rs
+++ b/layercake-core/src/common/handlebars.rs
@@ -60,6 +60,26 @@ pub fn get_handlebars() -> Handlebars<'static> {
     });
     handlebars.register_helper("inline", Box::new(inline));
 
+    // Emit a value as a YAML double-quoted scalar, escaping backslashes,
+    // quotes, and collapsing newlines. Needed for Mermaid frontmatter fields
+    // like `title:` — an unquoted title containing ':' breaks YAML parsing and
+    // Mermaid rejects the whole diagram.
+    handlebars_helper!(yaml_quote: |v: Value| {
+        let s = match v {
+            Value::String(s) => s,
+            Value::Null => String::new(),
+            other => other.to_string(),
+        };
+        let escaped = s
+            .replace('\\', "\\\\")
+            .replace('"', "\\\"")
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ");
+        format!("\"{}\"", escaped)
+    });
+    handlebars.register_helper("yaml_quote", Box::new(yaml_quote));
+
     handlebars_helper!(is_empty: |v: Value| {
         match v {
             serde_json::Value::Array(arr) => arr.is_empty(),

--- a/layercake-core/src/database/migrations/m20260715_000002_normalise_sequence_edge_order.rs
+++ b/layercake-core/src/database/migrations/m20260715_000002_normalise_sequence_edge_order.rs
@@ -1,0 +1,75 @@
+use sea_orm::Statement;
+use sea_orm_migration::prelude::*;
+
+/// Normalise `sequences.edge_order` to the canonical camelCase JSON shape.
+///
+/// The GraphQL boundary type used to serialise edge refs in snake_case
+/// (`dataset_id`, `edge_id`, `note_position`) with PascalCase note positions
+/// (`"Source"`), while the pipeline consumer expects camelCase (`datasetId`,
+/// `edgeId`, `notePosition`) with lowercase positions (`"source"`). Rows written
+/// before the fix parse to an empty vector, producing empty diagrams. This
+/// rewrites the keys and note-position values to the canonical shape.
+///
+/// The key renames are unambiguous within `edge_order`. The value renames
+/// (`"Source"`→`"source"` etc.) are scoped by first requiring the row to still
+/// contain the old `note_position` key, so we only touch rows that were written
+/// in the old shape.
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+const KEY_RENAMES: &[(&str, &str)] = &[
+    ("\"dataset_id\"", "\"datasetId\""),
+    ("\"edge_id\"", "\"edgeId\""),
+];
+
+const VALUE_RENAMES: &[(&str, &str)] = &[
+    ("\"note_position\":\"Source\"", "\"notePosition\":\"source\""),
+    ("\"note_position\":\"Target\"", "\"notePosition\":\"target\""),
+    ("\"note_position\":\"Both\"", "\"notePosition\":\"both\""),
+    // Spaced variant (serde_json default has no space, but be defensive).
+    ("\"note_position\": \"Source\"", "\"notePosition\": \"source\""),
+    ("\"note_position\": \"Target\"", "\"notePosition\": \"target\""),
+    ("\"note_position\": \"Both\"", "\"notePosition\": \"both\""),
+    // Any remaining note_position key (e.g. null) → notePosition.
+    ("\"note_position\"", "\"notePosition\""),
+];
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+        let backend = manager.get_database_backend();
+
+        // Rename note-position values first (they still reference the old key),
+        // then any leftover key, then the other keys.
+        for (from, to) in VALUE_RENAMES.iter().chain(KEY_RENAMES.iter()) {
+            let sql = format!(
+                "UPDATE sequences SET edge_order = REPLACE(edge_order, '{from}', '{to}') WHERE edge_order LIKE '%{from}%'"
+            );
+            db.execute(Statement::from_string(backend, sql)).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Best-effort reverse to the old snake_case shape.
+        let db = manager.get_connection();
+        let backend = manager.get_database_backend();
+        let reverses: &[(&str, &str)] = &[
+            ("\"datasetId\"", "\"dataset_id\""),
+            ("\"edgeId\"", "\"edge_id\""),
+            ("\"notePosition\":\"source\"", "\"note_position\":\"Source\""),
+            ("\"notePosition\":\"target\"", "\"note_position\":\"Target\""),
+            ("\"notePosition\":\"both\"", "\"note_position\":\"Both\""),
+            ("\"notePosition\"", "\"note_position\""),
+        ];
+        for (from, to) in reverses {
+            let sql = format!(
+                "UPDATE sequences SET edge_order = REPLACE(edge_order, '{from}', '{to}') WHERE edge_order LIKE '%{from}%'"
+            );
+            db.execute(Statement::from_string(backend, sql)).await?;
+        }
+        Ok(())
+    }
+}

--- a/layercake-core/src/database/migrations/mod.rs
+++ b/layercake-core/src/database/migrations/mod.rs
@@ -49,6 +49,7 @@ mod m20251216_000001_add_import_export_path_to_projects;
 mod m20260123_000001_create_plan_dag_annotations;
 mod m20260709_000001_rebuild_graph_edits_drop_graphs_fk;
 mod m20260715_000001_drop_code_analysis_profiles;
+mod m20260715_000002_normalise_sequence_edge_order;
 
 pub struct Migrator;
 
@@ -105,6 +106,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260123_000001_create_plan_dag_annotations::Migration),
             Box::new(m20260709_000001_rebuild_graph_edits_drop_graphs_fk::Migration),
             Box::new(m20260715_000001_drop_code_analysis_profiles::Migration),
+            Box::new(m20260715_000002_normalise_sequence_edge_order::Migration),
         ]
     }
 }

--- a/layercake-core/src/doctor.rs
+++ b/layercake-core/src/doctor.rs
@@ -1,0 +1,361 @@
+//! Project health diagnostics (`layercake doctor`).
+//!
+//! Scans a project for the classes of problem that otherwise only surface as
+//! silent-empty output: orphaned computed graphs, unresolvable sequence edge
+//! references, plan DAG nodes pointing at missing datasets, and empty sequence
+//! contexts. The logic lives in core so it can back both the CLI command and a
+//! future GraphQL endpoint, and so it is unit-testable.
+
+use anyhow::Result;
+use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+
+#[cfg(test)]
+use crate::database::entities::projects;
+use crate::database::entities::{
+    data_sets, graph_data, plan_dag_nodes, plans, sequence_contexts, sequences, stories,
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Finding {
+    pub severity: Severity,
+    /// Short machine-readable category, e.g. "orphaned-computed-graph".
+    pub check: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DoctorReport {
+    pub project_id: i32,
+    pub findings: Vec<Finding>,
+}
+
+impl DoctorReport {
+    pub fn is_healthy(&self) -> bool {
+        self.findings.is_empty()
+    }
+    pub fn error_count(&self) -> usize {
+        self.findings
+            .iter()
+            .filter(|f| f.severity == Severity::Error)
+            .count()
+    }
+}
+
+/// Run all diagnostics for a project.
+pub async fn run_diagnostics(db: &DatabaseConnection, project_id: i32) -> Result<DoctorReport> {
+    let mut findings = Vec::new();
+
+    // Resolve the project's plan node ids (nodes are scoped by plan_id).
+    let plan_ids: Vec<i32> = plans::Entity::find()
+        .filter(plans::Column::ProjectId.eq(project_id))
+        .all(db)
+        .await?
+        .into_iter()
+        .map(|p| p.id)
+        .collect();
+
+    let nodes = if plan_ids.is_empty() {
+        Vec::new()
+    } else {
+        plan_dag_nodes::Entity::find()
+            .filter(plan_dag_nodes::Column::PlanId.is_in(plan_ids.clone()))
+            .all(db)
+            .await?
+    };
+    let node_ids: HashSet<String> = nodes.iter().map(|n| n.id.clone()).collect();
+
+    // Dataset PKs that exist (for the missing-dataset check).
+    let dataset_ids: HashSet<i32> = data_sets::Entity::find()
+        .filter(data_sets::Column::ProjectId.eq(project_id))
+        .all(db)
+        .await?
+        .into_iter()
+        .map(|d| d.id)
+        .collect();
+
+    check_nodes_reference_existing_datasets(&nodes, &dataset_ids, &mut findings);
+    check_orphaned_computed_graphs(db, project_id, &node_ids, &mut findings).await?;
+    check_sequence_contexts(db, project_id, &mut findings).await?;
+    check_story_sequences_resolve(db, project_id, &mut findings).await?;
+
+    Ok(DoctorReport {
+        project_id,
+        findings,
+    })
+}
+
+/// Plan DAG nodes whose `config.dataSetId` points at a dataset that no longer
+/// exists in this project.
+fn check_nodes_reference_existing_datasets(
+    nodes: &[plan_dag_nodes::Model],
+    dataset_ids: &HashSet<i32>,
+    findings: &mut Vec<Finding>,
+) {
+    for node in nodes {
+        let config: serde_json::Value = match serde_json::from_str(&node.config_json) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let linked = config
+            .get("dataSetId")
+            .or_else(|| config.get("datasetId"))
+            .and_then(|v| v.as_i64())
+            .map(|v| v as i32);
+        if let Some(id) = linked {
+            if !dataset_ids.contains(&id) {
+                findings.push(Finding {
+                    severity: Severity::Error,
+                    check: "node-missing-dataset".into(),
+                    message: format!(
+                        "plan node '{}' ({}) references dataset {} which does not exist",
+                        node.id, node.node_type, id
+                    ),
+                });
+            }
+        }
+    }
+}
+
+/// Computed `graph_data` rows whose originating DAG node is gone.
+async fn check_orphaned_computed_graphs(
+    db: &DatabaseConnection,
+    project_id: i32,
+    node_ids: &HashSet<String>,
+    findings: &mut Vec<Finding>,
+) -> Result<()> {
+    let graphs = graph_data::Entity::find()
+        .filter(graph_data::Column::ProjectId.eq(project_id))
+        .all(db)
+        .await?;
+    for g in graphs {
+        if g.source_type == "computed" {
+            if let Some(dag_node_id) = &g.dag_node_id {
+                if !node_ids.contains(dag_node_id) {
+                    findings.push(Finding {
+                        severity: Severity::Warning,
+                        check: "orphaned-computed-graph".into(),
+                        message: format!(
+                            "computed graph '{}' (id {}) originates from DAG node '{}' which no longer exists",
+                            g.name, g.id, dag_node_id
+                        ),
+                    });
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Persisted sequence contexts that are empty (no participants), which render
+/// as blank diagrams.
+async fn check_sequence_contexts(
+    db: &DatabaseConnection,
+    project_id: i32,
+    findings: &mut Vec<Finding>,
+) -> Result<()> {
+    let contexts = sequence_contexts::Entity::find()
+        .filter(sequence_contexts::Column::ProjectId.eq(project_id))
+        .all(db)
+        .await?;
+    for ctx in contexts {
+        let parsed: serde_json::Value = match serde_json::from_str(&ctx.context_json) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let participant_count = parsed
+            .get("participants")
+            .and_then(|v| v.as_array())
+            .map(|a| a.len())
+            .unwrap_or(0);
+        if participant_count == 0 {
+            findings.push(Finding {
+                severity: Severity::Warning,
+                check: "empty-sequence-context".into(),
+                message: format!(
+                    "sequence context for node '{}' (story {}) has no participants — its diagram will be empty",
+                    ctx.node_id, ctx.story_id
+                ),
+            });
+        }
+        // Surface any warnings recorded when the context was built.
+        if let Some(warns) = parsed.get("warnings").and_then(|v| v.as_array()) {
+            for w in warns {
+                if let Some(text) = w.as_str() {
+                    findings.push(Finding {
+                        severity: Severity::Warning,
+                        check: "sequence-context-warning".into(),
+                        message: format!("node '{}': {}", ctx.node_id, text),
+                    });
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Stories whose sequences reference edges that don't resolve against the
+/// enabled datasets — the classic "green but empty" author error.
+async fn check_story_sequences_resolve(
+    db: &DatabaseConnection,
+    project_id: i32,
+    findings: &mut Vec<Finding>,
+) -> Result<()> {
+    let story_models = stories::Entity::find()
+        .filter(stories::Column::ProjectId.eq(project_id))
+        .all(db)
+        .await?;
+    for story in story_models {
+        // Reuse the real context builder so this check matches actual rendering.
+        match crate::sequence_context::build_story_context(db, project_id, story.id).await {
+            Ok(ctx) => {
+                for w in ctx.warnings {
+                    findings.push(Finding {
+                        severity: Severity::Warning,
+                        check: "story-sequence-unresolved".into(),
+                        message: format!("story '{}' (id {}): {}", story.name, story.id, w),
+                    });
+                }
+                let has_sequences = sequences::Entity::find()
+                    .filter(sequences::Column::StoryId.eq(story.id))
+                    .one(db)
+                    .await?
+                    .is_some();
+                if has_sequences && ctx.participants.is_empty() {
+                    findings.push(Finding {
+                        severity: Severity::Error,
+                        check: "story-empty".into(),
+                        message: format!(
+                            "story '{}' (id {}) has sequences but resolves to zero participants",
+                            story.name, story.id
+                        ),
+                    });
+                }
+            }
+            Err(e) => findings.push(Finding {
+                severity: Severity::Error,
+                check: "story-build-failed".into(),
+                message: format!("story '{}' (id {}): {}", story.name, story.id, e),
+            }),
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::test_utils::setup_test_db;
+    use chrono::Utc;
+    use sea_orm::{ActiveModelTrait, Set};
+
+    async fn seed_base(db: &DatabaseConnection) {
+        projects::ActiveModel {
+            id: Set(1),
+            name: Set("P".into()),
+            description: Set(None),
+            tags: Set("[]".into()),
+            import_export_path: Set(None),
+            created_at: Set(Utc::now().into()),
+            updated_at: Set(Utc::now().into()),
+        }
+        .insert(db)
+        .await
+        .unwrap();
+
+        data_sets::ActiveModel {
+            id: Set(10),
+            project_id: Set(1),
+            name: Set("ds".into()),
+            description: Set(None),
+            file_format: Set("json".into()),
+            data_type: Set("graph".into()),
+            origin: Set("manual_edit".into()),
+            filename: Set("ds.json".into()),
+            blob: Set(Vec::new()),
+            graph_json: Set(
+                r#"{"nodes":[{"id":"n1","label":"A","layer":"l","weight":1}],"edges":[],"layers":[]}"#
+                    .into(),
+            ),
+            status: Set("active".into()),
+            error_message: Set(None),
+            file_size: Set(0),
+            processed_at: Set(None),
+            created_at: Set(Utc::now().into()),
+            updated_at: Set(Utc::now().into()),
+            annotations: Set(None),
+        }
+        .insert(db)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn healthy_empty_project_has_no_findings() {
+        let db = setup_test_db().await;
+        seed_base(&db).await;
+        let report = run_diagnostics(&db, 1).await.unwrap();
+        assert!(report.is_healthy(), "{:?}", report.findings);
+    }
+
+    #[tokio::test]
+    async fn flags_story_with_unresolvable_edge() {
+        let db = setup_test_db().await;
+        seed_base(&db).await;
+
+        stories::ActiveModel {
+            id: Set(1),
+            project_id: Set(1),
+            name: Set("Story1".into()),
+            description: Set(None),
+            tags: Set("[]".into()),
+            enabled_dataset_ids: Set("[10]".into()),
+            layer_config: Set("[]".into()),
+            created_at: Set(Utc::now().into()),
+            updated_at: Set(Utc::now().into()),
+        }
+        .insert(&db)
+        .await
+        .unwrap();
+
+        sequences::ActiveModel {
+            id: Set(1),
+            story_id: Set(1),
+            name: Set("seq".into()),
+            description: Set(None),
+            enabled_dataset_ids: Set("[10]".into()),
+            edge_order: Set(r#"[{"datasetId":10,"edgeId":"nope"}]"#.into()),
+            created_at: Set(Utc::now()),
+            updated_at: Set(Utc::now()),
+        }
+        .insert(&db)
+        .await
+        .unwrap();
+
+        let report = run_diagnostics(&db, 1).await.unwrap();
+        assert!(!report.is_healthy());
+        assert!(
+            report
+                .findings
+                .iter()
+                .any(|f| f.check == "story-sequence-unresolved" && f.message.contains("nope")),
+            "expected unresolved-edge finding: {:?}",
+            report.findings
+        );
+        assert!(
+            report.findings.iter().any(|f| f.check == "story-empty"),
+            "expected empty-story finding: {:?}",
+            report.findings
+        );
+        assert!(report.error_count() >= 1);
+    }
+}

--- a/layercake-core/src/export/mod.rs
+++ b/layercake-core/src/export/mod.rs
@@ -388,4 +388,29 @@ mod tests {
             "missing_layer class should be present"
         );
     }
+
+    #[test]
+    fn test_mermaid_frontmatter_title_with_colon_is_quoted() {
+        use crate::export::to_mermaid;
+
+        // A ':' in the graph name used to produce `title: Netwealth: PDLC`,
+        // which is invalid YAML frontmatter and made Mermaid reject the diagram.
+        let graph = Graph {
+            name: "Netwealth: PDLC".to_string(),
+            nodes: vec![create_node("n1", "Node 1", "l1")],
+            edges: vec![],
+            layers: vec![create_layer("l1")],
+            annotations: None,
+        };
+        let config = create_test_config();
+        let result = to_mermaid::render(&graph, &config).unwrap();
+
+        // Title must be a quoted YAML scalar, not raw text with a bare colon.
+        assert!(
+            result.contains(r#"title: "Netwealth: PDLC""#),
+            "title should be quoted:\n{result}"
+        );
+        // And it must NOT be HTML-escaped (would be &quot;).
+        assert!(!result.contains("&quot;"), "title should not be HTML-escaped:\n{result}");
+    }
 }

--- a/layercake-core/src/export/sequence_renderer.rs
+++ b/layercake-core/src/export/sequence_renderer.rs
@@ -236,4 +236,48 @@ mod tests {
         // Partition box grouping with layer colour.
         assert!(out.contains(r#"box "Group One" #00ff00"#), "{out}");
     }
+
+    fn ctx_with_note(position: &str) -> SequenceRenderContext {
+        let mut ctx = SequenceRenderContext::default();
+        ctx.config.show_notes = true;
+        ctx.participants = vec![participant("a", "A", None), participant("b", "B", None)];
+        ctx.first_participant_alias = Some("a".into());
+        ctx.last_participant_alias = Some("b".into());
+        ctx.sequences = vec![SequenceRender {
+            id: 1,
+            name: "S".into(),
+            description: None,
+            steps: vec![SequenceStep {
+                id: "s".into(),
+                dataset_id: 1,
+                dataset_name: "d".into(),
+                source: SequenceParticipantRef { alias: "a".into(), label: "A".into() },
+                target: SequenceParticipantRef { alias: "b".into(), label: "B".into() },
+                label: "x".into(),
+                note: Some("N".into()),
+                note_position: Some(position.into()),
+            }],
+        }];
+        ctx
+    }
+
+    // Regression for the {{else if}} mis-route: handlebars-rust treats a
+    // block-standalone `{{else if}}` as a plain `{{else}}`, so the "target"
+    // branch was dead and always fell through to "both". Nested else/if fixes it.
+    #[test]
+    fn note_position_routes_correctly_mermaid() {
+        let src = to_mermaid_sequence::render(&ctx_with_note("source")).unwrap();
+        assert!(src.contains("Note over a: N") && !src.contains("Note over a,b: N"), "{src}");
+        let tgt = to_mermaid_sequence::render(&ctx_with_note("target")).unwrap();
+        assert!(tgt.contains("Note over b: N") && !tgt.contains("Note over a,b: N"), "{tgt}");
+        let both = to_mermaid_sequence::render(&ctx_with_note("both")).unwrap();
+        assert!(both.contains("Note over a,b: N"), "{both}");
+    }
+
+    #[test]
+    fn note_position_routes_correctly_plantuml() {
+        let tgt = to_plantuml_sequence::render(&ctx_with_note("target")).unwrap();
+        assert!(tgt.contains("note over b\nN"), "{tgt}");
+        assert!(!tgt.contains("note over a,b\nN"), "{tgt}");
+    }
 }

--- a/layercake-core/src/export/to_mermaid.hbs
+++ b/layercake-core/src/export/to_mermaid.hbs
@@ -1,5 +1,5 @@
 ---
-{{#if graph_name}}title: {{graph_name}}
+{{#if graph_name}}title: {{{yaml_quote graph_name}}}
 {{/if}}{{#with config.target_options.mermaid as |mm|}}
 config:
   look: {{mm.look}}

--- a/layercake-core/src/export/to_mermaid_mindmap.hbs
+++ b/layercake-core/src/export/to_mermaid_mindmap.hbs
@@ -1,5 +1,5 @@
 ---
-{{#if graph_name}}title: {{graph_name}}
+{{#if graph_name}}title: {{{yaml_quote graph_name}}}
 {{/if}}{{#with config.target_options.mermaid as |mm|}}
 config:
   theme: {{mm.theme}}

--- a/layercake-core/src/export/to_mermaid_sequence.hbs
+++ b/layercake-core/src/export/to_mermaid_sequence.hbs
@@ -28,10 +28,12 @@ end
         {{#if note}}
           {{#if (stringeq notePosition "source")}}
     Note over {{source.alias}}: {{inline note}}
-          {{else if (stringeq notePosition "target")}}
-    Note over {{target.alias}}: {{inline note}}
           {{else}}
+            {{#if (stringeq notePosition "target")}}
+    Note over {{target.alias}}: {{inline note}}
+            {{else}}
     Note over {{source.alias}},{{target.alias}}: {{inline note}}
+            {{/if}}
           {{/if}}
         {{/if}}
       {{/if}}

--- a/layercake-core/src/export/to_mermaid_treemap.hbs
+++ b/layercake-core/src/export/to_mermaid_treemap.hbs
@@ -1,5 +1,5 @@
 ---
-{{#if graph_name}}title: {{graph_name}}
+{{#if graph_name}}title: {{{yaml_quote graph_name}}}
 {{/if}}{{#with config.target_options.mermaid as |mm|}}
 config:
   look: {{mm.look}}

--- a/layercake-core/src/export/to_plantuml_sequence.hbs
+++ b/layercake-core/src/export/to_plantuml_sequence.hbs
@@ -27,14 +27,16 @@ participant {{alias}} as "{{inline label}}"{{#if layerColor}} {{layerColor}}{{/i
 note over {{source.alias}}
 {{inline note}}
 end note
-          {{else if (stringeq notePosition "target")}}
+          {{else}}
+            {{#if (stringeq notePosition "target")}}
 note over {{target.alias}}
 {{inline note}}
 end note
-          {{else}}
+            {{else}}
 note over {{source.alias}},{{target.alias}}
 {{inline note}}
 end note
+            {{/if}}
           {{/if}}
         {{/if}}
       {{/if}}

--- a/layercake-core/src/lib.rs
+++ b/layercake-core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod pipeline;
 pub mod plan;
 pub mod plan_dag;
 pub mod plan_execution;
+pub mod doctor;
 pub mod sequence_context;
 pub mod sequence_types;
 pub mod story_types;

--- a/layercake-core/src/pipeline/dag_executor.rs
+++ b/layercake-core/src/pipeline/dag_executor.rs
@@ -292,6 +292,9 @@ impl DagExecutor {
                     .story_id
                     .ok_or_else(|| anyhow!("Story node {} is not configured", node_id))?;
                 let story_context = build_story_context(&self.db, project_id, story_id).await?;
+                for warning in &story_context.warnings {
+                    tracing::warn!(node = %node_id, story = story_id, "{}", warning);
+                }
                 self.persist_story_context(project_id, node_id, story_id, &story_context)
                     .await?;
             }

--- a/layercake-core/src/sequence_context.rs
+++ b/layercake-core/src/sequence_context.rs
@@ -24,6 +24,11 @@ pub struct SequenceStoryContext {
     pub participants: Vec<SequenceParticipant>,
     pub graph_data: SequenceGraphData,
     pub layers: Vec<SequenceLayer>,
+    /// Non-fatal problems encountered while building the context (e.g. a
+    /// sequence edge reference that didn't resolve). Surfaced so an empty or
+    /// partial diagram is never silently reported as success.
+    #[serde(default)]
+    pub warnings: Vec<String>,
 }
 
 pub async fn build_story_context(
@@ -77,7 +82,7 @@ pub async fn build_story_context(
         tags: serde_json::from_str::<Vec<String>>(&story.tags).unwrap_or_default(),
     };
 
-    let (sequence_entries, participants_map) = build_sequence_entries(
+    let (sequence_entries, participants_map, mut warnings) = build_sequence_entries(
         &sequence_models,
         &dataset_contexts,
         &layer_overrides,
@@ -97,12 +102,22 @@ pub async fn build_story_context(
 
     let layer_entries = graph_data.layers.clone();
 
+    if !sequence_models.is_empty() && participants.is_empty() {
+        warnings.push(format!(
+            "story '{}' (id {}): {} sequence(s) produced no participants — the diagram will be empty",
+            story_summary.name,
+            story_summary.id,
+            sequence_models.len()
+        ));
+    }
+
     Ok(SequenceStoryContext {
         story: story_summary,
         sequences: sequence_entries,
         participants,
         graph_data,
         layers: layer_entries,
+        warnings,
     })
 }
 
@@ -387,10 +402,12 @@ fn build_sequence_entries(
 ) -> (
     Vec<SequenceRender>,
     IndexMap<(i32, String), SequenceParticipant>,
+    Vec<String>,
 ) {
     let mut participants: IndexMap<(i32, String), SequenceParticipant> = IndexMap::new();
     let mut alias_set: HashSet<String> = HashSet::new();
     let mut results = Vec::new();
+    let mut warnings: Vec<String> = Vec::new();
 
     let mut all_nodes: HashMap<String, &SequenceNode> = HashMap::new();
     for ctx in dataset_contexts.values() {
@@ -400,32 +417,63 @@ fn build_sequence_entries(
     }
 
     for sequence in sequences {
-        let edge_order: Vec<SequenceEdgeRef> =
-            serde_json::from_str(&sequence.edge_order).unwrap_or_default();
+        let edge_order: Vec<SequenceEdgeRef> = match serde_json::from_str(&sequence.edge_order) {
+            Ok(order) => order,
+            Err(e) => {
+                warnings.push(format!(
+                    "sequence '{}' (id {}): could not parse edge_order ({}); it will render empty",
+                    sequence.name, sequence.id, e
+                ));
+                Vec::new()
+            }
+        };
+        let requested_steps = edge_order.len();
         let mut steps = Vec::new();
 
         for (index, edge_ref) in edge_order.into_iter().enumerate() {
             let dataset = match dataset_contexts.get(&edge_ref.dataset_id) {
                 Some(ctx) => ctx,
                 None => {
+                    warnings.push(format!(
+                        "sequence '{}' step {}: dataset {} is not enabled for this story",
+                        sequence.name, index, edge_ref.dataset_id
+                    ));
                     continue;
                 }
             };
 
             let edge = match resolve_edge(dataset, &edge_ref.edge_id) {
                 Some(edge) => edge,
-                None => continue,
+                None => {
+                    warnings.push(format!(
+                        "sequence '{}' step {}: edge '{}' not found in dataset {}",
+                        sequence.name, index, edge_ref.edge_id, edge_ref.dataset_id
+                    ));
+                    continue;
+                }
             };
 
             let source_node = match all_nodes.get(&edge.source) {
                 Some(node) => node,
-                None => continue,
+                None => {
+                    warnings.push(format!(
+                        "sequence '{}' step {}: source node '{}' of edge '{}' not found",
+                        sequence.name, index, edge.source, edge_ref.edge_id
+                    ));
+                    continue;
+                }
             };
             let source_dataset = dataset_contexts.get(&source_node.dataset_id).unwrap();
 
             let target_node = match all_nodes.get(&edge.target) {
                 Some(node) => node,
-                None => continue,
+                None => {
+                    warnings.push(format!(
+                        "sequence '{}' step {}: target node '{}' of edge '{}' not found",
+                        sequence.name, index, edge.target, edge_ref.edge_id
+                    ));
+                    continue;
+                }
             };
             let target_dataset = dataset_contexts.get(&target_node.dataset_id).unwrap();
 
@@ -478,6 +526,15 @@ fn build_sequence_entries(
             });
         }
 
+        // A sequence that requested steps but resolved none is the classic
+        // "green but empty" case — make it loud.
+        if requested_steps > 0 && steps.is_empty() {
+            warnings.push(format!(
+                "sequence '{}' (id {}): all {} step(s) were skipped; it will render empty",
+                sequence.name, sequence.id, requested_steps
+            ));
+        }
+
         results.push(SequenceRender {
             id: sequence.id,
             name: sequence.name.clone(),
@@ -486,7 +543,7 @@ fn build_sequence_entries(
         });
     }
 
-    (results, participants)
+    (results, participants, warnings)
 }
 
 fn get_or_create_participant<'a>(
@@ -763,7 +820,7 @@ mod story_participant_tests {
     fn only_story_edges_become_participants_and_steps() {
         let contexts = ctx_with(vec![edge("e1","n1","n2","calls")]);
         let sequences = vec![seq(&["e1"])];
-        let (results, participants) = build_sequence_entries(&sequences, &contexts, &HashMap::new(), &HashMap::new(), true);
+        let (results, participants, _warnings) = build_sequence_entries(&sequences, &contexts, &HashMap::new(), &HashMap::new(), true);
         // Exactly 2 participants (n1,n2) — NOT n3.
         assert_eq!(participants.len(), 2, "participants: {:?}", participants.keys().collect::<Vec<_>>());
         assert_eq!(results.len(), 1);
@@ -779,7 +836,7 @@ mod story_participant_tests {
         // so we still get the story's participants/steps — not zero.
         let contexts = ctx_with(vec![edge("n1:n2", "n1", "n2", "calls")]);
         let sequences = vec![seq(&["n1:n2"])];
-        let (results, participants) =
+        let (results, participants, _warnings) =
             build_sequence_entries(&sequences, &contexts, &HashMap::new(), &HashMap::new(), true);
         assert_eq!(participants.len(), 2);
         assert_eq!(results[0].steps.len(), 1);
@@ -792,7 +849,7 @@ mod story_participant_tests {
         // The fallback matches by endpoints.
         let contexts = ctx_with(vec![edge("e1", "n1", "n2", "calls")]);
         let sequences = vec![seq(&["n1:n2"])];
-        let (results, participants) =
+        let (results, participants, _warnings) =
             build_sequence_entries(&sequences, &contexts, &HashMap::new(), &HashMap::new(), true);
         assert_eq!(participants.len(), 2);
         assert_eq!(results[0].steps.len(), 1);
@@ -802,7 +859,7 @@ mod story_participant_tests {
     fn edge_comment_is_appended_to_message_label() {
         let contexts = ctx_with(vec![edge_c("e1", "n1", "n2", "calls", "async")]);
         let sequences = vec![seq(&["e1"])];
-        let (results, _) =
+        let (results, _, _) =
             build_sequence_entries(&sequences, &contexts, &HashMap::new(), &HashMap::new(), true);
         assert_eq!(results[0].steps[0].label, "calls: async");
     }
@@ -813,9 +870,18 @@ mod story_participant_tests {
         // as a participant — it renders empty.
         let contexts = ctx_with(vec![edge("e1", "n1", "n2", "calls")]);
         let sequences = vec![seq(&["does-not-exist"])];
-        let (results, participants) =
+        let (results, participants, warnings) =
             build_sequence_entries(&sequences, &contexts, &HashMap::new(), &HashMap::new(), true);
         assert_eq!(participants.len(), 0, "must not include unrelated nodes");
         assert_eq!(results[0].steps.len(), 0);
+        // ...and it must be surfaced as a warning, not silently green.
+        assert!(
+            warnings.iter().any(|w| w.contains("does-not-exist")),
+            "expected an unresolved-edge warning, got: {warnings:?}"
+        );
+        assert!(
+            warnings.iter().any(|w| w.contains("all 1 step(s) were skipped")),
+            "expected an empty-sequence warning, got: {warnings:?}"
+        );
     }
 }

--- a/layercake-server/src/graphql/mutations/sequence.rs
+++ b/layercake-server/src/graphql/mutations/sequence.rs
@@ -4,6 +4,7 @@ use sea_orm::{ActiveModelTrait, EntityTrait, Set};
 
 use crate::graphql::context::GraphQLContext;
 use crate::graphql::errors::StructuredError;
+use crate::graphql::types::sequence::edge_refs_to_persisted_json;
 use crate::graphql::types::{CreateSequenceInput, Sequence, UpdateSequenceInput};
 use layercake_core::database::entities::sequences;
 
@@ -33,7 +34,7 @@ impl SequenceMutation {
                 ))
             })?;
 
-        let edge_order_json = serde_json::to_string(&input.edge_order.unwrap_or_default())
+        let edge_order_json = edge_refs_to_persisted_json(input.edge_order.unwrap_or_default())
             .map_err(|e| {
                 StructuredError::bad_request(format!("Failed to serialize edge_order: {}", e))
             })?;
@@ -98,7 +99,7 @@ impl SequenceMutation {
         }
 
         if let Some(edge_order) = input.edge_order {
-            let json = serde_json::to_string(&edge_order).map_err(|e| {
+            let json = edge_refs_to_persisted_json(edge_order).map_err(|e| {
                 StructuredError::bad_request(format!("Failed to serialize edge_order: {}", e))
             })?;
             sequence.edge_order = Set(json);

--- a/layercake-server/src/graphql/types/plan_dag/node.rs
+++ b/layercake-server/src/graphql/types/plan_dag/node.rs
@@ -83,6 +83,23 @@ impl PlanDagNode {
         // For now, return the raw JSON. In the future, this could parse to specific types
         Ok(self.config.clone())
     }
+
+    /// The dataset primary key this node references, if any.
+    ///
+    /// Plan DAG nodes are keyed by opaque hash ids (e.g. `dataset_766f8bef…`),
+    /// while dataset/graph mutations take the integer PK. The link lives inside
+    /// the node's `config` JSON (`dataSetId`); this surfaces it as a first-class
+    /// field so agents don't have to parse `config` by hand to join the two.
+    #[graphql(name = "linkedDataSetId")]
+    async fn linked_data_set_id(&self) -> Option<i32> {
+        let config: serde_json::Value = serde_json::from_str(&self.config).ok()?;
+        config
+            .get("dataSetId")
+            .or_else(|| config.get("datasetId"))
+            .or_else(|| config.get("dataSetId"))
+            .and_then(|v| v.as_i64())
+            .map(|v| v as i32)
+    }
 }
 
 // Conversions from database entities

--- a/layercake-server/src/graphql/types/sequence.rs
+++ b/layercake-server/src/graphql/types/sequence.rs
@@ -8,17 +8,29 @@ use crate::graphql::types::Story;
 use layercake_core::database::entities::{sequences, stories};
 
 /// Note position for sequence edge annotations
+///
+/// serde uses camelCase (lowercase variants) to match the persisted / pipeline
+/// shape; GraphQL uses PascalCase for the enum items. The two renamings are
+/// independent (serde ≠ GraphQL wire), and both must stay aligned with
+/// `layercake_core::sequence_types::NotePosition`.
 #[derive(Clone, Debug, Serialize, Deserialize, Enum, Copy, PartialEq, Eq)]
 #[graphql(name = "SequenceNotePosition", rename_items = "PascalCase")]
+#[serde(rename_all = "camelCase")]
 pub enum NotePosition {
     Source,
     Target,
     Both,
 }
 
-/// Reference to an edge in a dataset
+/// Reference to an edge in a dataset (GraphQL boundary type).
+///
+/// This is the API-facing shape only. The persisted (DB) representation is
+/// owned by the pipeline type `layercake_core::sequence_types::SequenceEdgeRef`
+/// — the mutation converts to it before serializing, so there is exactly one
+/// on-disk shape. Do NOT `serde_json::to_string` this type into the database.
 #[derive(Clone, Debug, Serialize, Deserialize, SimpleObject, InputObject)]
 #[graphql(input_name = "SequenceEdgeRefInput")]
+#[serde(rename_all = "camelCase")]
 pub struct SequenceEdgeRef {
     #[graphql(name = "datasetId")]
     pub dataset_id: i32,
@@ -29,6 +41,37 @@ pub struct SequenceEdgeRef {
     /// Where to display the note: Source, Target, or Both
     #[graphql(name = "notePosition")]
     pub note_position: Option<NotePosition>,
+}
+
+impl From<NotePosition> for layercake_core::sequence_types::NotePosition {
+    fn from(value: NotePosition) -> Self {
+        match value {
+            NotePosition::Source => layercake_core::sequence_types::NotePosition::Source,
+            NotePosition::Target => layercake_core::sequence_types::NotePosition::Target,
+            NotePosition::Both => layercake_core::sequence_types::NotePosition::Both,
+        }
+    }
+}
+
+impl From<SequenceEdgeRef> for layercake_core::sequence_types::SequenceEdgeRef {
+    fn from(value: SequenceEdgeRef) -> Self {
+        layercake_core::sequence_types::SequenceEdgeRef {
+            dataset_id: value.dataset_id,
+            edge_id: value.edge_id,
+            note: value.note,
+            note_position: value.note_position.map(Into::into),
+        }
+    }
+}
+
+/// Serialize a list of API edge refs to the canonical persisted JSON shape
+/// (owned by the pipeline `SequenceEdgeRef`).
+pub fn edge_refs_to_persisted_json(
+    refs: Vec<SequenceEdgeRef>,
+) -> Result<String, serde_json::Error> {
+    let pipeline: Vec<layercake_core::sequence_types::SequenceEdgeRef> =
+        refs.into_iter().map(Into::into).collect();
+    serde_json::to_string(&pipeline)
 }
 
 #[derive(SimpleObject)]
@@ -106,4 +149,43 @@ pub struct UpdateSequenceInput {
     pub enabled_dataset_ids: Option<Vec<i32>>,
     #[graphql(name = "edgeOrder")]
     pub edge_order: Option<Vec<SequenceEdgeRef>>,
+}
+
+#[cfg(test)]
+mod b1_tests {
+    use super::*;
+
+    #[test]
+    fn persisted_json_parses_into_pipeline_type() {
+        let refs = vec![SequenceEdgeRef {
+            dataset_id: 5,
+            edge_id: "e1".into(),
+            note: Some("hi".into()),
+            note_position: Some(NotePosition::Target),
+        }];
+        let json = edge_refs_to_persisted_json(refs).unwrap();
+        // Canonical shape: camelCase keys + lowercase note position.
+        assert!(json.contains("\"datasetId\":5"), "{json}");
+        assert!(json.contains("\"edgeId\":\"e1\""), "{json}");
+        assert!(json.contains("\"notePosition\":\"target\""), "{json}");
+        // And it must round-trip into the pipeline consumer without loss.
+        let parsed: Vec<layercake_core::sequence_types::SequenceEdgeRef> =
+            serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].edge_id, "e1");
+        assert!(matches!(
+            parsed[0].note_position,
+            Some(layercake_core::sequence_types::NotePosition::Target)
+        ));
+    }
+
+    #[test]
+    fn api_type_reads_back_what_pipeline_wrote() {
+        // The GraphQL read path (From<Model>) parses edge_order with the API
+        // type; it must accept the canonical camelCase shape.
+        let json = r#"[{"datasetId":5,"edgeId":"e1","note":null,"notePosition":"source"}]"#;
+        let parsed: Vec<SequenceEdgeRef> = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed[0].dataset_id, 5);
+        assert!(matches!(parsed[0].note_position, Some(NotePosition::Source)));
+    }
 }

--- a/layercake-server/src/graphql/types/story.rs
+++ b/layercake-server/src/graphql/types/story.rs
@@ -82,6 +82,23 @@ impl Story {
 
         Ok(count as i32)
     }
+
+    /// The sequences that belong to this story, ordered by id.
+    async fn sequences(&self, ctx: &Context<'_>) -> Result<Vec<crate::graphql::types::Sequence>> {
+        use sea_orm::{ColumnTrait, QueryFilter, QueryOrder};
+
+        let context = ctx.data::<GraphQLContext>()?;
+        let models = sequences::Entity::find()
+            .filter(sequences::Column::StoryId.eq(self.id))
+            .order_by_asc(sequences::Column::Id)
+            .all(&context.db)
+            .await?;
+
+        Ok(models
+            .into_iter()
+            .map(crate::graphql::types::Sequence::from)
+            .collect())
+    }
 }
 
 #[derive(InputObject)]

--- a/plans/20260715-tool-review-001-uplift.md
+++ b/plans/20260715-tool-review-001-uplift.md
@@ -2,6 +2,7 @@
 
 **Date:** 2026-07-15
 **Source:** `reviews/tool-review-001.md` (agent-driven session on project 36).
+**Status:** Stages 1–7 complete (branch `fix/tool-review-uplift`).
 **Approach:** structural fixes over patches (unify seams, remove masking fallbacks, make failures visible). Validate every finding against current `master` before acting — several sequence-area items overlap recent PRs (#79/#80), so state may differ from the review.
 
 ## Validation of review findings (done against current master)

--- a/plans/20260715-tool-review-001-uplift.md
+++ b/plans/20260715-tool-review-001-uplift.md
@@ -1,0 +1,76 @@
+# Uplift plan — tool-review-001
+
+**Date:** 2026-07-15
+**Source:** `reviews/tool-review-001.md` (agent-driven session on project 36).
+**Approach:** structural fixes over patches (unify seams, remove masking fallbacks, make failures visible). Validate every finding against current `master` before acting — several sequence-area items overlap recent PRs (#79/#80), so state may differ from the review.
+
+## Validation of review findings (done against current master)
+
+| # | Finding | Status after validation | Notes |
+|---|---------|--------------------------|-------|
+| **B1** | `SequenceEdgeRef` serde case mismatch API↔pipeline | **CONFIRMED, still broken** | API type (`sequence.rs:20`) has only `#[graphql(name=...)]`, no `#[serde(rename_all)]` → writes snake_case + `"Source"/"Target"/"Both"` to `sequences.edge_order`. Pipeline type (`sequence_types.rs`) is camelCase + lowercase. `serde_json::to_string(&input.edge_order)` (mutations/sequence.rs:36,101) writes the API shape; `sequence_context.rs` reads the pipeline shape → parses to empty. **This is the true root cause of empty diagrams**; PR #80's `resolve_edge` is downstream and never runs. |
+| **B2** | Handlebars `{{else if}}` rejected | **CONFIRMED, nuanced** | Isolated `render_template` with inline `{{else if}}` errors `Helper not defined: "else"`. The `.hbs` uses the block-standalone form, which does NOT error but **silently mis-routes** — `notePosition:"target"` renders as the `{{else}}` (both) branch. So the target-note branch is dead. Present in `to_mermaid_sequence.hbs:31` and `to_plantuml_sequence.hbs:30`. |
+| **NEW** | Mermaid frontmatter title breaks on `:` | **CONFIRMED** | `title: {{graph_name}}` (unquoted YAML) in `to_mermaid.hbs:2`, `to_mermaid_mindmap.hbs:2`, `to_mermaid_treemap.hbs:2`. A title containing `:` produces invalid frontmatter → Mermaid parse error. |
+| F1 | `api info` prints hardcoded 3000 | CONFIRMED | `api.rs` builds URL from `--port` default 3000; doesn't verify against a running server. |
+| F2 | Silent skips in sequence pipeline | CONFIRMED (partially mitigated) | PR #80 removed the all-nodes fallback; still `continue`s silently on unresolved edges/nodes with no warning surfaced. |
+| F3 | Numeric vs hash node id bridge | CONFIRMED | `PlanDagNode` doesn't expose the `config.dataSetId` link as a first-class field. |
+| F4 | GraphJson boilerplate undocumented | CONFIRMED | No `graph-json` guide; `updateDataSetGraphData` requires `weight`/`layers`. |
+| F5 | NodeMetadata subfield selection | CONFIRMED (doc) | Docs don't mention `{ label description }`. |
+| F6 | Static vs generated ids; orphaned graphs | CONFIRMED | No prune; lifecycle undocumented. |
+| F7 | StoryNode upstream is decorative | CONFIRMED | Context builder uses `story.enabledDatasetIds`, ignores DAG upstream. |
+| D2 | `showNotes` not in schema | **PARTIALLY FIXED** | `SequenceRenderConfigInput` with `show_notes`/`render_all_sequences`/`contain_nodes` EXISTS (`config.rs:176`). Need to verify it's wired to the artefact config path (vs the JSON-string `config` bypass) and update the doc. |
+| D3 | Story `sequences` field missing | CONFIRMED | Story exposes `sequenceCount` (`story.rs:73`), not `sequences`. Doc query fails. |
+| D5 | Node types undocumented | CONFIRMED | No `guide node-types`. |
+
+## Stages
+
+Ordered by impact and independence. Each stage builds, tests, and commits on its own (structural fixes first, then diagnostics, then docs). Backend fixes on `fix/tool-review-uplift`; larger additive features may split to their own branches.
+
+### Stage 1 — B1: unify `SequenceEdgeRef` serialization (root seam) [STRUCTURAL]
+The two same-named types with incompatible serde is the architectural defect. **Single source of truth:** make the persisted representation canonical and unambiguous.
+- Give the API `SequenceEdgeRef` + `NotePosition` (`sequence.rs`) `#[serde(rename_all = "camelCase")]` and lowercase `NotePosition` serde renames so the *serde* (DB) shape matches the pipeline exactly. (GraphQL names already match via `#[graphql(name)]`.)
+- **Better structural option (evaluate):** have the mutation persist via the *pipeline* `sequence_types::SequenceEdgeRef` (convert API→pipeline once at the boundary), so there is one on-disk shape owned by one type. Prefer this if the conversion is clean.
+- One-shot migration to rewrite existing `sequences.edge_order` rows from snake_case→camelCase (and `NotePosition` case), idempotent.
+- Test: round-trip create→persist→`build_story_context` yields non-empty steps; a golden test asserting the persisted JSON shape.
+**Status:** Not Started
+
+### Stage 2 — B2: fix `{{else if}}` mis-routing in sequence templates [CORRECTNESS]
+Rewrite the note-position branch as nested `{{else}}{{#if …}}…{{/if}}` (handlebars-rust supported) in both `to_mermaid_sequence.hbs` and `to_plantuml_sequence.hbs`. Add a render test asserting `notePosition:"target"` → `Note over <target>` (not both).
+**Status:** Not Started
+
+### Stage 3 — NEW: quote Mermaid frontmatter title [CORRECTNESS]
+Quote + escape the title in `to_mermaid.hbs`, `to_mermaid_mindmap.hbs`, `to_mermaid_treemap.hbs` (`title: "{{graph_name}}"` with `"`→`\"`), or add a handlebars helper. Test a title containing `:` produces valid frontmatter.
+**Status:** Not Started
+
+### Stage 4 — F2/Rec2: pipeline warnings instead of silent skips [ARCHITECTURE]
+Structural: thread a warnings channel through sequence building so "sequence N skipped M of K steps: unresolved edge X" is collected and surfaced in the node execution result. Make silent-green impossible.
+- Add `warnings: Vec<String>` to the story-context build path; propagate into `NodeExecutionResult`/execution annotations.
+- Test: an unresolvable edge yields a warning, not silence.
+**Status:** Not Started
+
+### Stage 5 — F3/Rec5: expose the dataset id bridge on PlanDagNode [ARCHITECTURE]
+Add `linkedDataSetId: Int` (computed from `config.dataSetId`) to `PlanDagNode` GraphQL type. Low-risk, high-discoverability.
+**Status:** Not Started
+
+### Stage 6 — D2/D3/D5 + docs: schema + guides [DOCS/SCHEMA]
+- D3: add a `sequences: [Sequence!]!` resolver on `Story` (the doc's query should work), keep `sequenceCount`.
+- D2: verify `SequenceRenderConfigInput` is honoured on the artefact config path; update `develop-a-story` doc to reference real fields; document the JSON-`config` vs typed-input situation.
+- D5: `layercake doc guide node-types` (each `PlanDagNodeType`, its config, io types).
+- F4: `layercake doc guide graph-json`.
+- F5: note in `edit-a-plan` about `{ label description }`.
+- D1: reconcile port docs (3000 default, note per-project override).
+**Status:** Not Started
+
+### Stage 7 (own branch) — Rec1: `layercake doctor` diagnostics command [FEATURE]
+Scan a project for: orphaned computed graphs, sequence edge refs that don't resolve, plan DAG nodes referencing missing datasets, empty sequence contexts, layer duplicates. Emits a report. This operationalises everything the reviewer diagnosed by hand.
+**Status:** Not Started (candidate for separate PR)
+
+### Deferred / evaluate (not committed without sign-off)
+- F1 `api info` live port detection — modest; do a lightweight `/health` probe of a candidate port and report verified vs default.
+- F6 `pruneOrphanedGraphs` mutation + lifecycle docs.
+- F7 make StoryNode DAG upstream real, or enforce DataSetNode-only + auto-enable — a behaviour decision, needs product input.
+- Rec3 higher-level CLI shorthands (`api story-list`, etc.).
+- Rec4/FR: `schema type <Name>`, `--only-mutations/--only-inputs`, `exportProject`, story-preview endpoint, palette presets. Feature requests — surface as issues, implement on request.
+
+## Guiding principle
+Per user: prefer structural/architecturally sound solutions; uplift design; unify seams rather than patch. B1 and F2 are the clearest examples — fix the seam and remove the masking, don't add a translator.


### PR DESCRIPTION
Implements the uplift plan from `reviews/tool-review-001.md`. Every finding was validated (with reproduction tests) against master before fixing; structural fixes preferred over patches per project direction. Plan: `plans/20260715-tool-review-001-uplift.md`.

## Blocking bugs (these stopped diagrams rendering)

**B1 — SequenceEdgeRef serialization seam** (`96705ded`). The GraphQL boundary type serialized `edge_order` as snake_case + PascalCase note positions, but the pipeline consumer expects camelCase + lowercase — so every sequence parsed to empty (empty diagram, "success" response). This is the true root cause behind the empty-diagram symptom. **Structural fix:** persist via the pipeline `sequence_types::SequenceEdgeRef` (one on-disk shape), align the API type's serde, and migrate existing rows (`m20260715_000002`).

**B2 — `{{else if}}` mis-routing** (`05848025`). handlebars-rust treats block-standalone `{{else if}}` as a plain `{{else}}` and drops the condition, so `notePosition:target` notes silently rendered as `both`. Rewrote as nested `{{else}}{{#if}}` in both sequence templates.

**Mermaid frontmatter title** (`54de9036`) — a `:` in the graph name (e.g. "Netwealth: PDLC") produced invalid YAML frontmatter and Mermaid rejected the diagram. Added a `yaml_quote` helper and quoted the title in the three mermaid templates.

## Architecture / discoverability

- **Pipeline warnings** (`764831ae`, F2) — unresolved edges/nodes were silently skipped; now collected on `SequenceStoryContext.warnings`, logged by the executor, persisted in context. Silent-green is gone.
- **`PlanDagNode.linkedDataSetId`** (`6a5d4e80`, F3) — first-class hash-id ↔ dataset-PK bridge.
- **`Story.sequences`** resolver + **`doc guide node-types`** + **`doc guide graph-json`** + edit-a-plan doc notes (`de02456d`, D3/D5/F4/F5).
- **`layercake doctor`** (`fe8a2c3f`, Rec1) — scans a project for missing-dataset nodes, orphaned computed graphs, empty sequence contexts, and unresolvable story sequences. Logic in `layercake_core::doctor` (unit-tested, reusable for a future GraphQL endpoint); CLI is a thin wrapper; `--json`, non-zero exit on errors.

## Verification
186 core lib tests + server tests pass; `cargo build --workspace` clean. Each bug has a regression test (B1 round-trip, B2 note routing, frontmatter quoting, warning emission, doctor findings).

## Deferred (flagged in the plan, not in this PR)
F1 live-port detection, F6 orphaned-graph prune + lifecycle, F7 StoryNode-upstream behaviour (product decision), and the remaining feature requests (`schema type <Name>`, `exportProject`, etc.) — surface as issues on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)