### PR TITLE
Tool-review deferred items: F1, F6, F7, exportProject/preview, schema tooling

### DIFF
--- a/docs-tool/command/schema.md
+++ b/docs-tool/command/schema.md
@@ -6,8 +6,11 @@ database is required, because the type system does not depend on runtime data.
 ## Usage
 
 ```bash
-layercake schema dump            # GraphQL SDL (schema definition language)
-layercake schema dump --json     # introspection JSON (for codegen/tooling)
+layercake schema dump                 # full GraphQL SDL
+layercake schema dump --json          # introspection JSON (for codegen/tooling)
+layercake schema dump --only-inputs   # just the input object types
+layercake schema dump --only-mutations# just the Mutation root
+layercake schema type <Name>          # one type's SDL, e.g. SequenceEdgeRefInput
 ```
 
 ## Examples

--- a/docs-tool/guide/node-types.md
+++ b/docs-tool/guide/node-types.md
@@ -22,7 +22,12 @@ To join a node back to its dataset PK, read `PlanDagNode.linkedDataSetId`
 - **DataSetNode** — brings a dataset's graph into the plan. `config.dataSetId`
   links to the dataset PK. Deleting the node does NOT delete the dataset.
 - **GraphNode** — a computed graph produced by upstream processing; the unit
-  that gets executed into `graph_data`.
+  that gets executed into `graph_data` (`source_type='computed'`, tagged with
+  its `dag_node_id`). **Lifecycle:** deleting the GraphNode from the DAG does
+  NOT auto-delete its computed `graph_data` — it becomes an *orphan* that still
+  appears in `graphs(projectId)`. Run `layercake doctor` to detect orphans and
+  the `pruneOrphanedGraphs(projectId)` mutation to remove them. (Datasets behind
+  a deleted DataSetNode are likewise never auto-deleted.)
 
 ### Transform / combine nodes
 

--- a/docs-tool/workflow/develop-a-story.md
+++ b/docs-tool/workflow/develop-a-story.md
@@ -5,6 +5,18 @@ Stories turn graph nodes and edges into **sequence diagrams with commentary** �
 a core use case: you read a dataset's graph, choose an ordered path of edges,
 attach commentary, and render a sequence diagram.
 
+## Sourcing: datasets vs computed graphs
+
+A story sources its edges from either:
+- **`enabledDatasetIds`** — raw dataset PKs (`data_sets`), or
+- **`enabledGraphIds`** — computed graph ids (`graph_data`, a GraphNode's
+  output). Use this to build a story from a *merged* graph rather than raw
+  datasets.
+
+A `SequenceEdgeRef.datasetId` may be either a dataset id OR a computed graph id;
+whatever you enabled on the story. (Frontend picker for computed graphs is a
+follow-up — set `enabledGraphIds` via the API for now.)
+
 ## Mental model
 
 - A **Story** is a curated collection of **Sequences** (belongs to a project,

--- a/docs-tool/workflow/develop-a-story.md
+++ b/docs-tool/workflow/develop-a-story.md
@@ -120,6 +120,21 @@ sequenceDiagram
   ...
 ```
 
+## Preview without rendering
+
+To inspect the resolved participants/steps/warnings (or render the diagram
+yourself client-side) without the Handlebars template:
+
+```bash
+layercake api call --query '
+  query($p:Int!,$s:Int!){ previewStoryContext(projectId:$p, storyId:$s) }' \
+  --variables '{"p":1,"s":42}'
+```
+
+Returns the `SequenceStoryContext` as JSON (participants, sequences[].steps,
+and any build `warnings`). If `steps` is empty or `warnings` is non-empty, the
+diagram will be blank — run `layercake doctor --project <id>` to see why.
+
 ## Summary of the ops, in order
 
 `createStory` → `createSequence` (×N) → `updatePlanDag` (add StoryNode +

--- a/layercake-cli/src/api.rs
+++ b/layercake-cli/src/api.rs
@@ -29,12 +29,64 @@ struct ApiInfo {
     collaboration_ws: String,
     session_header: &'static str,
     database: String,
+    /// Whether the server actually responded on `/health`.
+    reachable: bool,
+    /// The version reported by the running server, if reachable.
+    server_version: Option<String>,
+    /// If the requested port wasn't reachable, other localhost ports that are.
+    detected_ports: Vec<u16>,
 }
 
-/// Print the endpoints and headers for a running server.
-pub fn info(url: Option<&str>, host: &str, port: u16, database: &str, json_out: bool) -> Result<()> {
+/// Probe `/health` at a base URL; return the reported version on success.
+async fn probe_health(base: &str) -> Option<String> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_millis(600))
+        .build()
+        .ok()?;
+    let resp = client.get(format!("{}/health", base)).send().await.ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    let body: serde_json::Value = resp.json().await.ok()?;
+    // Treat any healthy JSON as reachable; surface version if present.
+    Some(
+        body.get("version")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown")
+            .to_string(),
+    )
+}
+
+/// Print the endpoints and headers for a running server, verifying against a
+/// live `/health` probe rather than trusting the requested port blindly.
+pub async fn info(
+    url: Option<&str>,
+    host: &str,
+    port: u16,
+    database: &str,
+    json_out: bool,
+) -> Result<()> {
     let base = base_url(url, host, port);
     let ws_base = base.replacen("http", "ws", 1);
+
+    let server_version = probe_health(&base).await;
+    let reachable = server_version.is_some();
+
+    // If the requested endpoint isn't answering, scan a few common local ports
+    // so the user isn't stuck on the "wrong port" trap.
+    let mut detected_ports = Vec::new();
+    if !reachable && url.is_none() {
+        for candidate in [3000u16, 3001, 8080, 8000] {
+            if candidate == port {
+                continue;
+            }
+            let candidate_base = format!("http://{}:{}", host, candidate);
+            if probe_health(&candidate_base).await.is_some() {
+                detected_ports.push(candidate);
+            }
+        }
+    }
+
     let info = ApiInfo {
         graphql: format!("{}/graphql", base),
         graphql_ws: format!("{}/graphql/ws", ws_base),
@@ -43,6 +95,9 @@ pub fn info(url: Option<&str>, host: &str, port: u16, database: &str, json_out: 
         session_header: "x-layercake-session",
         database: database.to_string(),
         base_url: base,
+        reachable,
+        server_version,
+        detected_ports,
     };
 
     if json_out {
@@ -55,6 +110,21 @@ pub fn info(url: Option<&str>, host: &str, port: u16, database: &str, json_out: 
         println!("Collaboration (WS): {}", info.collaboration_ws);
         println!("Session header:     {}: <id>", info.session_header);
         println!("Database file:      {}", info.database);
+        match &info.server_version {
+            Some(v) => println!("Server:             reachable (version {})", v),
+            None => {
+                println!("Server:             NOT reachable at this address");
+                if !info.detected_ports.is_empty() {
+                    let hint: Vec<String> =
+                        info.detected_ports.iter().map(|p| p.to_string()).collect();
+                    println!(
+                        "                    a layercake server IS answering on port(s): {} — try --port {}",
+                        hint.join(", "),
+                        info.detected_ports[0]
+                    );
+                }
+            }
+        }
     }
     Ok(())
 }

--- a/layercake-cli/src/main.rs
+++ b/layercake-cli/src/main.rs
@@ -171,6 +171,17 @@ enum SchemaCommands {
         /// Emit introspection JSON instead of SDL
         #[clap(long)]
         json: bool,
+        /// Only the Mutation root type
+        #[clap(long)]
+        only_mutations: bool,
+        /// Only input object types
+        #[clap(long)]
+        only_inputs: bool,
+    },
+    /// Print a single type's SDL (type / input / enum / …)
+    Type {
+        /// The type name, e.g. SequenceEdgeRefInput
+        name: String,
     },
 }
 
@@ -328,7 +339,12 @@ async fn main() -> Result<()> {
             DocCommands::Guide { name } => doc::print_doc("guide", &name)?,
         },
         Commands::Schema { command } => match command {
-            SchemaCommands::Dump { json } => schema_dump::dump(json).await?,
+            SchemaCommands::Dump {
+                json,
+                only_mutations,
+                only_inputs,
+            } => schema_dump::dump(json, only_mutations, only_inputs).await?,
+            SchemaCommands::Type { name } => schema_dump::print_type(&name)?,
         },
         Commands::Doctor {
             project,

--- a/layercake-cli/src/main.rs
+++ b/layercake-cli/src/main.rs
@@ -344,7 +344,7 @@ async fn main() -> Result<()> {
                 port,
                 database,
                 json,
-            } => api::info(url.as_deref(), &host, port, &database, json)?,
+            } => api::info(url.as_deref(), &host, port, &database, json).await?,
             ApiCommands::Call {
                 query,
                 variables,

--- a/layercake-cli/src/schema_dump.rs
+++ b/layercake-cli/src/schema_dump.rs
@@ -4,14 +4,100 @@
 //! database or request context needed to generate the type system), so agents
 //! can learn the full API without booting a server.
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 
-/// Print the GraphQL SDL. With `json`, print the introspection result instead.
-pub async fn dump(json: bool) -> Result<()> {
+/// Print the GraphQL SDL. Filters narrow the output; `json` prints the
+/// introspection result instead (ignores filters).
+pub async fn dump(json: bool, only_mutations: bool, only_inputs: bool) -> Result<()> {
     if json {
         println!("{}", layercake_server::graphql::introspection_json().await?);
-    } else {
-        print!("{}", layercake_server::graphql::sdl());
+        return Ok(());
+    }
+
+    let sdl = layercake_server::graphql::sdl();
+    if !only_mutations && !only_inputs {
+        print!("{}", sdl);
+        return Ok(());
+    }
+
+    for block in sdl_blocks(&sdl) {
+        let keep = (only_inputs && block.trim_start().starts_with("input "))
+            || (only_mutations && is_mutation_block(&block));
+        if keep {
+            println!("{}\n", block.trim_end());
+        }
     }
     Ok(())
+}
+
+/// Print just the named type's SDL block (type / input / enum / interface /
+/// union / scalar).
+pub fn print_type(name: &str) -> Result<()> {
+    let sdl = layercake_server::graphql::sdl();
+    for block in sdl_blocks(&sdl) {
+        if block_defines(&block, name) {
+            print!("{}", block);
+            return Ok(());
+        }
+    }
+    Err(anyhow!(
+        "type '{}' not found in the schema (try `layercake schema dump | grep -i {}`)",
+        name,
+        name
+    ))
+}
+
+/// Split an SDL string into top-level definition blocks. A block starts at a
+/// line beginning a definition keyword and runs to its closing `}` (or the line
+/// itself for one-line defs like `scalar`).
+fn sdl_blocks(sdl: &str) -> Vec<String> {
+    const KEYWORDS: [&str; 6] = ["type ", "input ", "enum ", "interface ", "union ", "scalar "];
+    let mut blocks = Vec::new();
+    let mut current = String::new();
+    let mut depth = 0i32;
+    let mut in_block = false;
+
+    for line in sdl.lines() {
+        if !in_block && KEYWORDS.iter().any(|k| line.starts_with(k)) {
+            in_block = true;
+            current = String::new();
+        }
+        if in_block {
+            current.push_str(line);
+            current.push('\n');
+            depth += line.matches('{').count() as i32;
+            depth -= line.matches('}').count() as i32;
+
+            let block_has_brace = current.contains('{');
+            let complete = if block_has_brace {
+                depth <= 0 // multi-line brace block closed
+            } else {
+                true // one-line def (e.g. `scalar Foo`)
+            };
+            if complete {
+                blocks.push(std::mem::take(&mut current));
+                in_block = false;
+                depth = 0;
+            }
+        }
+    }
+    if !current.trim().is_empty() {
+        blocks.push(current);
+    }
+    blocks
+}
+
+fn block_defines(block: &str, name: &str) -> bool {
+    let first = block.lines().next().unwrap_or("");
+    // "type Foo {" / "input Foo {" / "enum Foo {" / "scalar Foo"
+    first
+        .split_whitespace()
+        .nth(1)
+        .map(|n| n.trim_end_matches('{').trim() == name)
+        .unwrap_or(false)
+}
+
+fn is_mutation_block(block: &str) -> bool {
+    let first = block.lines().next().unwrap_or("");
+    first.starts_with("type Mutation")
 }

--- a/layercake-core/src/app_context/graph_operations.rs
+++ b/layercake-core/src/app_context/graph_operations.rs
@@ -434,6 +434,18 @@ impl AppContext {
             .map_err(|e| CoreError::internal("Failed to update graph data").with_source(e))
     }
 
+    /// Delete computed graphs whose originating DAG node no longer exists.
+    /// Returns the pruned graph ids.
+    pub async fn prune_orphaned_graphs(
+        &self,
+        actor: &Actor,
+        project_id: i32,
+    ) -> CoreResult<Vec<i32>> {
+        self.authorize_project_write(actor, project_id).await?;
+        let service = crate::services::GraphDataService::new(self.db.clone());
+        service.prune_orphaned_graphs(project_id).await
+    }
+
     pub async fn replay_graph_data_edits(
         &self,
         actor: &Actor,

--- a/layercake-core/src/app_context/library_operations.rs
+++ b/layercake-core/src/app_context/library_operations.rs
@@ -1371,6 +1371,7 @@ impl AppContext {
                 enabled_dataset_ids: Set(
                     serde_json::to_string(&mapped_dataset_ids).unwrap_or_else(|_| "[]".into())
                 ),
+                enabled_graph_ids: Set("[]".into()),
                 layer_config: Set(
                     serde_json::to_string(&story.layer_config).unwrap_or_else(|_| "{}".into())
                 ),

--- a/layercake-core/src/app_context/preview_operations.rs
+++ b/layercake-core/src/app_context/preview_operations.rs
@@ -54,6 +54,22 @@ impl AppContext {
         Ok(apply_preview_limit(content, format, max_rows))
     }
 
+    /// Build the story's `SequenceStoryContext` and return it as JSON, without
+    /// running it through a Handlebars template. Lets a client render the
+    /// diagram itself (and inspect participants/steps/warnings directly).
+    pub async fn preview_story_context_json(
+        &self,
+        _actor: &Actor,
+        project_id: i32,
+        story_id: i32,
+    ) -> CoreResult<String> {
+        let context = build_story_context(&self.db, project_id, story_id)
+            .await
+            .map_err(|e| CoreError::internal(format!("Failed to build story context: {}", e)))?;
+        serde_json::to_string(&context)
+            .map_err(|e| CoreError::internal(format!("Failed to serialize story context: {}", e)))
+    }
+
     #[allow(dead_code)]
     pub async fn preview_sequence_export(
         &self,

--- a/layercake-core/src/app_context/project_operations.rs
+++ b/layercake-core/src/app_context/project_operations.rs
@@ -64,6 +64,95 @@ impl AppContext {
         Ok(project.map(ProjectSummary::from))
     }
 
+    /// Export a full project (datasets, plan DAG, stories, sequences, layers) as
+    /// a single JSON document — for snapshotting a session or reproducing a bug.
+    /// Read access is authorized on the project.
+    pub async fn export_project_json(
+        &self,
+        actor: &Actor,
+        project_id: i32,
+    ) -> CoreResult<serde_json::Value> {
+        use crate::database::entities::{
+            data_sets, plan_dag_edges, plan_dag_nodes, plans, project_layers, sequences, stories,
+        };
+        use sea_orm::{ColumnTrait, QueryFilter};
+
+        self.authorize_project_read(actor, project_id).await?;
+
+        fn load_err(what: &'static str) -> impl Fn(sea_orm::DbErr) -> CoreError {
+            move |e| CoreError::internal(format!("export: {}: {}", what, e))
+        }
+
+        let project = projects::Entity::find_by_id(project_id)
+            .one(&self.db)
+            .await
+            .map_err(load_err("project"))?
+            .ok_or_else(|| CoreError::not_found("Project", project_id.to_string()))?;
+
+        let datasets = data_sets::Entity::find()
+            .filter(data_sets::Column::ProjectId.eq(project_id))
+            .all(&self.db)
+            .await
+            .map_err(load_err("datasets"))?;
+
+        let plan_models = plans::Entity::find()
+            .filter(plans::Column::ProjectId.eq(project_id))
+            .all(&self.db)
+            .await
+            .map_err(load_err("plans"))?;
+        let plan_ids: Vec<i32> = plan_models.iter().map(|p| p.id).collect();
+
+        let (dag_nodes, dag_edges) = if plan_ids.is_empty() {
+            (Vec::new(), Vec::new())
+        } else {
+            let nodes = plan_dag_nodes::Entity::find()
+                .filter(plan_dag_nodes::Column::PlanId.is_in(plan_ids.clone()))
+                .all(&self.db)
+                .await
+                .map_err(load_err("plan_dag_nodes"))?;
+            let edges = plan_dag_edges::Entity::find()
+                .filter(plan_dag_edges::Column::PlanId.is_in(plan_ids.clone()))
+                .all(&self.db)
+                .await
+                .map_err(load_err("plan_dag_edges"))?;
+            (nodes, edges)
+        };
+
+        let story_models = stories::Entity::find()
+            .filter(stories::Column::ProjectId.eq(project_id))
+            .all(&self.db)
+            .await
+            .map_err(load_err("stories"))?;
+        let story_ids: Vec<i32> = story_models.iter().map(|s| s.id).collect();
+        let sequence_models = if story_ids.is_empty() {
+            Vec::new()
+        } else {
+            sequences::Entity::find()
+                .filter(sequences::Column::StoryId.is_in(story_ids))
+                .all(&self.db)
+                .await
+                .map_err(load_err("sequences"))?
+        };
+
+        let layers = project_layers::Entity::find()
+            .filter(project_layers::Column::ProjectId.eq(project_id))
+            .all(&self.db)
+            .await
+            .map_err(load_err("project_layers"))?;
+
+        Ok(serde_json::json!({
+            "formatVersion": 1,
+            "project": project,
+            "datasets": datasets,
+            "plans": plan_models,
+            "planDagNodes": dag_nodes,
+            "planDagEdges": dag_edges,
+            "stories": story_models,
+            "sequences": sequence_models,
+            "projectLayers": layers,
+        }))
+    }
+
     pub async fn create_project(
         &self,
         actor: &Actor,

--- a/layercake-core/src/database/entities/stories.rs
+++ b/layercake-core/src/database/entities/stories.rs
@@ -13,6 +13,8 @@ pub struct Model {
     pub tags: String, // JSON array of strings
     #[sea_orm(column_type = "Text", default_value = "[]")]
     pub enabled_dataset_ids: String, // JSON array of dataset IDs
+    #[sea_orm(column_type = "Text", default_value = "[]")]
+    pub enabled_graph_ids: String, // JSON array of computed graph_data IDs
     #[sea_orm(column_type = "Text", default_value = "{}")]
     pub layer_config: String, // JSON layer configuration
     pub created_at: ChronoDateTimeUtc,

--- a/layercake-core/src/database/migrations/m20260715_000003_add_enabled_graph_ids_to_stories.rs
+++ b/layercake-core/src/database/migrations/m20260715_000003_add_enabled_graph_ids_to_stories.rs
@@ -1,0 +1,43 @@
+use sea_orm_migration::prelude::*;
+
+/// Add `enabled_graph_ids` to stories so a story can source edges from a
+/// computed graph (a GraphNode's output in `graph_data`) in addition to raw
+/// datasets. JSON array of `graph_data` ids; defaults to `[]`.
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Stories::Table)
+                    .add_column(
+                        ColumnDef::new(Stories::EnabledGraphIds)
+                            .text()
+                            .not_null()
+                            .default("[]"),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Stories::Table)
+                    .drop_column(Stories::EnabledGraphIds)
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum Stories {
+    Table,
+    EnabledGraphIds,
+}

--- a/layercake-core/src/database/migrations/mod.rs
+++ b/layercake-core/src/database/migrations/mod.rs
@@ -50,6 +50,7 @@ mod m20260123_000001_create_plan_dag_annotations;
 mod m20260709_000001_rebuild_graph_edits_drop_graphs_fk;
 mod m20260715_000001_drop_code_analysis_profiles;
 mod m20260715_000002_normalise_sequence_edge_order;
+mod m20260715_000003_add_enabled_graph_ids_to_stories;
 
 pub struct Migrator;
 
@@ -107,6 +108,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260709_000001_rebuild_graph_edits_drop_graphs_fk::Migration),
             Box::new(m20260715_000001_drop_code_analysis_profiles::Migration),
             Box::new(m20260715_000002_normalise_sequence_edge_order::Migration),
+            Box::new(m20260715_000003_add_enabled_graph_ids_to_stories::Migration),
         ]
     }
 }

--- a/layercake-core/src/doctor.rs
+++ b/layercake-core/src/doctor.rs
@@ -319,6 +319,7 @@ mod tests {
             description: Set(None),
             tags: Set("[]".into()),
             enabled_dataset_ids: Set("[10]".into()),
+            enabled_graph_ids: Set("[]".into()),
             layer_config: Set("[]".into()),
             created_at: Set(Utc::now().into()),
             updated_at: Set(Utc::now().into()),

--- a/layercake-core/src/sequence_context.rs
+++ b/layercake-core/src/sequence_context.rs
@@ -65,7 +65,17 @@ pub async fn build_story_context(
             .await?
     };
 
-    let dataset_contexts = build_dataset_contexts(&datasets);
+    let mut dataset_contexts = build_dataset_contexts(&datasets);
+
+    // A story may also source from computed graphs (a GraphNode's output). Load
+    // each enabled graph_data id as an additional context, keyed by its id so
+    // sequence edge refs can target it via `datasetId`.
+    let graph_ids = parse_story_graph_ids(&story.enabled_graph_ids);
+    for graph_id in graph_ids {
+        if let Some(ctx) = build_graph_data_context(db, graph_id).await? {
+            dataset_contexts.insert(ctx.dataset_id, ctx);
+        }
+    }
     let story_layer_config = parse_story_layer_config(&story.layer_config);
     let layer_overrides = build_story_layer_overrides(&story_layer_config);
 
@@ -171,6 +181,92 @@ pub fn apply_render_config(
 
 pub fn parse_story_dataset_ids(value: &str) -> Vec<i32> {
     serde_json::from_str(value).unwrap_or_default()
+}
+
+pub fn parse_story_graph_ids(value: &str) -> Vec<i32> {
+    serde_json::from_str(value).unwrap_or_default()
+}
+
+/// Load a computed graph (graph_data + its nodes/edges) into the same
+/// `ParsedDatasetContext` shape used for datasets, so a story can reference its
+/// edges. Keyed by the graph_data id. Returns None if the graph doesn't exist.
+async fn build_graph_data_context(
+    db: &DatabaseConnection,
+    graph_id: i32,
+) -> Result<Option<ParsedDatasetContext>> {
+    use crate::database::entities::{graph_data, graph_data_edges, graph_data_nodes};
+
+    let graph = match graph_data::Entity::find_by_id(graph_id).one(db).await? {
+        Some(g) => g,
+        None => return Ok(None),
+    };
+
+    let node_models = graph_data_nodes::Entity::find()
+        .filter(graph_data_nodes::Column::GraphDataId.eq(graph_id))
+        .all(db)
+        .await?;
+    let edge_models = graph_data_edges::Entity::find()
+        .filter(graph_data_edges::Column::GraphDataId.eq(graph_id))
+        .all(db)
+        .await?;
+
+    let mut nodes: IndexMap<String, SequenceNode> = IndexMap::new();
+    let mut partitions: HashMap<String, String> = HashMap::new();
+    for n in &node_models {
+        let label = n.label.clone().unwrap_or_else(|| n.external_id.clone());
+        if n.is_partition {
+            partitions.insert(n.external_id.clone(), label.clone());
+        }
+        nodes.insert(
+            n.external_id.clone(),
+            SequenceNode {
+                id: n.external_id.clone(),
+                label,
+                layer: n.layer.clone(),
+                dataset_id: graph.id,
+                dataset_name: graph.name.clone(),
+                belongs_to: n.belongs_to.clone(),
+                partition_label: None,
+                is_partition: n.is_partition,
+            },
+        );
+    }
+    for node in nodes.values_mut() {
+        if let Some(parent) = node.belongs_to.as_ref() {
+            if let Some(label) = partitions.get(parent) {
+                node.partition_label = Some(label.clone());
+            }
+        }
+    }
+
+    let mut edges: IndexMap<String, SequenceEdge> = IndexMap::new();
+    for e in &edge_models {
+        let edge_id = if e.external_id.is_empty() {
+            format!("{}:{}", e.source, e.target)
+        } else {
+            e.external_id.clone()
+        };
+        edges.insert(
+            edge_id.clone(),
+            SequenceEdge {
+                id: edge_id,
+                source: e.source.clone(),
+                target: e.target.clone(),
+                label: e.label.clone().unwrap_or_default(),
+                comment: e.comment.clone().filter(|c| !c.trim().is_empty()),
+                dataset_id: graph.id,
+                dataset_name: graph.name.clone(),
+            },
+        );
+    }
+
+    Ok(Some(ParsedDatasetContext {
+        dataset_id: graph.id,
+        name: graph.name,
+        nodes,
+        edges,
+        partitions,
+    }))
 }
 
 pub fn parse_story_layer_config(value: &str) -> Vec<StoryLayerConfig> {
@@ -883,5 +979,71 @@ mod story_participant_tests {
             warnings.iter().any(|w| w.contains("all 1 step(s) were skipped")),
             "expected an empty-sequence warning, got: {warnings:?}"
         );
+    }
+}
+
+#[cfg(test)]
+mod graph_source_tests {
+    use super::*;
+    use crate::database::entities::{
+        graph_data, graph_data_edges, graph_data_nodes, projects, stories,
+    };
+    use crate::database::test_utils::setup_test_db;
+    use chrono::Utc;
+    use sea_orm::{ActiveModelTrait, Set};
+
+    #[tokio::test]
+    async fn story_sources_edges_from_a_computed_graph() {
+        let db = setup_test_db().await;
+        projects::ActiveModel {
+            id: Set(1), name: Set("P".into()), description: Set(None), tags: Set("[]".into()),
+            import_export_path: Set(None), created_at: Set(Utc::now().into()), updated_at: Set(Utc::now().into()),
+        }.insert(&db).await.unwrap();
+
+        // A computed graph (graph_data id 500) with 2 nodes + 1 edge.
+        graph_data::ActiveModel {
+            id: Set(500), project_id: Set(1), name: Set("merged".into()),
+            source_type: Set("computed".into()), dag_node_id: Set(Some("gnode".into())),
+            last_edit_sequence: Set(0), has_pending_edits: Set(false),
+            node_count: Set(2), edge_count: Set(1), status: Set("active".into()),
+            created_at: Set(Utc::now()), updated_at: Set(Utc::now()),
+            ..Default::default()
+        }.insert(&db).await.unwrap();
+        for (ext, label) in [("a", "Alice"), ("b", "Bob")] {
+            graph_data_nodes::ActiveModel {
+                graph_data_id: Set(500), external_id: Set(ext.into()), label: Set(Some(label.into())),
+                layer: Set(None), weight: Set(Some(1.0)), is_partition: Set(false),
+                belongs_to: Set(None), comment: Set(None), source_dataset_id: Set(None),
+                attributes: Set(None), created_at: Set(Utc::now()),
+                ..Default::default()
+            }.insert(&db).await.unwrap();
+        }
+        graph_data_edges::ActiveModel {
+            graph_data_id: Set(500), external_id: Set("e1".into()), source: Set("a".into()),
+            target: Set("b".into()), label: Set(Some("calls".into())), layer: Set(None),
+            weight: Set(Some(1.0)), comment: Set(None), source_dataset_id: Set(None),
+            attributes: Set(None), created_at: Set(Utc::now()),
+            ..Default::default()
+        }.insert(&db).await.unwrap();
+
+        // Story sources from the computed graph (not a dataset), sequence uses e1.
+        stories::ActiveModel {
+            id: Set(1), project_id: Set(1), name: Set("S".into()), description: Set(None),
+            tags: Set("[]".into()), enabled_dataset_ids: Set("[]".into()),
+            enabled_graph_ids: Set("[500]".into()), layer_config: Set("[]".into()),
+            created_at: Set(Utc::now().into()), updated_at: Set(Utc::now().into()),
+        }.insert(&db).await.unwrap();
+        sequences::ActiveModel {
+            id: Set(1), story_id: Set(1), name: Set("seq".into()), description: Set(None),
+            enabled_dataset_ids: Set("[500]".into()),
+            edge_order: Set(r#"[{"datasetId":500,"edgeId":"e1"}]"#.into()),
+            created_at: Set(Utc::now()), updated_at: Set(Utc::now()),
+        }.insert(&db).await.unwrap();
+
+        let ctx = build_story_context(&db, 1, 1).await.unwrap();
+        assert_eq!(ctx.participants.len(), 2, "expected Alice+Bob from computed graph");
+        assert_eq!(ctx.sequences[0].steps.len(), 1);
+        assert_eq!(ctx.sequences[0].steps[0].label, "calls");
+        assert!(ctx.warnings.is_empty(), "warnings: {:?}", ctx.warnings);
     }
 }

--- a/layercake-core/src/services/graph_data_service.rs
+++ b/layercake-core/src/services/graph_data_service.rs
@@ -3,6 +3,7 @@ use crate::database::entities::{
     graph_data::GraphDataStatus,
     graph_data_edges, graph_data_nodes,
     graph_edits::{self, Entity as GraphEdits},
+    plan_dag_nodes, plans,
 };
 use crate::errors::{CoreError, CoreResult};
 use crate::services::graph_data_edit_applicator::{ApplyResult, GraphDataEditApplicator};
@@ -825,6 +826,90 @@ impl GraphDataService {
 
         Ok(result.rows_affected)
     }
+
+    /// Delete computed graphs whose originating plan DAG node no longer exists.
+    ///
+    /// Computed `graph_data` rows carry a `dag_node_id`; when the DAG is
+    /// reshaped and that node is removed, the computed graph is orphaned (it
+    /// still shows up in `graphs(projectId)` but has no live source). This
+    /// removes those rows and their nodes/edges. Returns the ids that were
+    /// pruned. Dataset/manual graphs are never touched.
+    pub async fn prune_orphaned_graphs(&self, project_id: i32) -> CoreResult<Vec<i32>> {
+        // Live DAG node ids for the project (nodes are scoped by plan_id).
+        let plan_ids: Vec<i32> = plans::Entity::find()
+            .filter(plans::Column::ProjectId.eq(project_id))
+            .all(&self.db)
+            .await
+            .map_err(|e| CoreError::internal("Failed to load plans").with_source(e))?
+            .into_iter()
+            .map(|p| p.id)
+            .collect();
+
+        let live_node_ids: std::collections::HashSet<String> = if plan_ids.is_empty() {
+            std::collections::HashSet::new()
+        } else {
+            plan_dag_nodes::Entity::find()
+                .filter(plan_dag_nodes::Column::PlanId.is_in(plan_ids))
+                .all(&self.db)
+                .await
+                .map_err(|e| CoreError::internal("Failed to load plan nodes").with_source(e))?
+                .into_iter()
+                .map(|n| n.id)
+                .collect()
+        };
+
+        let computed = graph_data::Entity::find()
+            .filter(graph_data::Column::ProjectId.eq(project_id))
+            .all(&self.db)
+            .await
+            .map_err(|e| CoreError::internal("Failed to load graph_data").with_source(e))?;
+
+        let mut pruned = Vec::new();
+        for g in computed {
+            if g.source_type == "computed" {
+                let orphaned = match &g.dag_node_id {
+                    Some(node_id) => !live_node_ids.contains(node_id),
+                    None => false, // no origin recorded → leave it alone
+                };
+                if orphaned {
+                    self.delete_graph_data_cascade(g.id).await?;
+                    pruned.push(g.id);
+                }
+            }
+        }
+
+        info!(project_id, count = pruned.len(), "Pruned orphaned computed graphs");
+        Ok(pruned)
+    }
+
+    /// Delete a graph_data row and its nodes/edges (FK-safe order).
+    async fn delete_graph_data_cascade(&self, graph_data_id: i32) -> CoreResult<()> {
+        let txn = self
+            .db
+            .begin()
+            .await
+            .map_err(|e| CoreError::internal("Failed to begin prune txn").with_source(e))?;
+
+        graph_data_edges::Entity::delete_many()
+            .filter(graph_data_edges::Column::GraphDataId.eq(graph_data_id))
+            .exec(&txn)
+            .await
+            .map_err(|e| CoreError::internal("Failed to delete graph_data edges").with_source(e))?;
+        graph_data_nodes::Entity::delete_many()
+            .filter(graph_data_nodes::Column::GraphDataId.eq(graph_data_id))
+            .exec(&txn)
+            .await
+            .map_err(|e| CoreError::internal("Failed to delete graph_data nodes").with_source(e))?;
+        graph_data::Entity::delete_by_id(graph_data_id)
+            .exec(&txn)
+            .await
+            .map_err(|e| CoreError::internal("Failed to delete graph_data row").with_source(e))?;
+
+        txn.commit()
+            .await
+            .map_err(|e| CoreError::internal("Failed to commit prune txn").with_source(e))?;
+        Ok(())
+    }
 }
 
 /// Summary of a replay operation
@@ -893,4 +978,103 @@ pub struct GraphDataEdgeInput {
     pub source_dataset_id: Option<i32>,
     pub attributes: Option<Value>,
     pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+#[cfg(test)]
+mod prune_tests {
+    use super::*;
+    use crate::database::entities::{plan_dag_nodes, plans, projects};
+    use crate::database::test_utils::setup_test_db;
+    use chrono::Utc;
+    use sea_orm::Set;
+
+    async fn seed_graph(db: &DatabaseConnection, id: i32, source_type: &str, dag_node_id: Option<&str>) {
+        graph_data::ActiveModel {
+            id: Set(id),
+            project_id: Set(1),
+            name: Set(format!("g{id}")),
+            source_type: Set(source_type.into()),
+            dag_node_id: Set(dag_node_id.map(|s| s.to_string())),
+            last_edit_sequence: Set(0),
+            has_pending_edits: Set(false),
+            node_count: Set(0),
+            edge_count: Set(0),
+            status: Set("active".into()),
+            created_at: Set(Utc::now()),
+            updated_at: Set(Utc::now()),
+            ..Default::default()
+        }
+        .insert(db)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn prunes_only_orphaned_computed_graphs() {
+        let db = setup_test_db().await;
+        projects::ActiveModel {
+            id: Set(1),
+            name: Set("P".into()),
+            description: Set(None),
+            tags: Set("[]".into()),
+            import_export_path: Set(None),
+            created_at: Set(Utc::now().into()),
+            updated_at: Set(Utc::now().into()),
+        }
+        .insert(&db)
+        .await
+        .unwrap();
+        plans::ActiveModel {
+            id: Set(1),
+            project_id: Set(1),
+            name: Set("plan".into()),
+            description: Set(None),
+            tags: Set("[]".into()),
+            yaml_content: Set("".into()),
+            dependencies: Set(None),
+            status: Set("active".into()),
+            version: Set(1),
+            created_at: Set(Utc::now().into()),
+            updated_at: Set(Utc::now().into()),
+        }
+        .insert(&db)
+        .await
+        .unwrap();
+        // Live DAG node "live_node".
+        plan_dag_nodes::ActiveModel {
+            id: Set("live_node".into()),
+            plan_id: Set(1),
+            node_type: Set("GraphNode".into()),
+            position_x: Set(0.0),
+            position_y: Set(0.0),
+            source_position: Set(None),
+            target_position: Set(None),
+            metadata_json: Set("{}".into()),
+            config_json: Set("{}".into()),
+            created_at: Set(Utc::now().into()),
+            updated_at: Set(Utc::now().into()),
+        }
+        .insert(&db)
+        .await
+        .unwrap();
+
+        seed_graph(&db, 10, "computed", Some("live_node")).await; // keep
+        seed_graph(&db, 11, "computed", Some("dead_node")).await; // prune
+        seed_graph(&db, 12, "dataset", None).await; // keep (not computed)
+        seed_graph(&db, 13, "computed", None).await; // keep (no origin)
+
+        let svc = GraphDataService::new(db.clone());
+        let pruned = svc.prune_orphaned_graphs(1).await.unwrap();
+        assert_eq!(pruned, vec![11]);
+
+        // 11 gone, others remain.
+        let remaining: Vec<i32> = graph_data::Entity::find()
+            .all(&db)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|g| g.id)
+            .collect();
+        assert_eq!(remaining, vec![10, 12, 13]);
+    }
 }

--- a/layercake-server/src/graphql/mutations/graph_data.rs
+++ b/layercake-server/src/graphql/mutations/graph_data.rs
@@ -27,6 +27,25 @@ impl GraphDataMutation {
         Ok(GraphData::from(updated))
     }
 
+    /// Delete computed graphs whose originating plan DAG node no longer exists.
+    /// Returns the ids of the graphs that were pruned. Dataset/manual graphs are
+    /// never affected.
+    #[graphql(name = "pruneOrphanedGraphs")]
+    async fn prune_orphaned_graphs(
+        &self,
+        ctx: &Context<'_>,
+        #[graphql(name = "projectId")] project_id: i32,
+    ) -> Result<Vec<i32>> {
+        let context = ctx.data::<GraphQLContext>()?;
+        let actor = context.actor_for_request(ctx).await;
+
+        context
+            .app
+            .prune_orphaned_graphs(&actor, project_id)
+            .await
+            .map_err(crate::graphql::errors::core_error_to_graphql_error)
+    }
+
     /// Replay edits for a graph_data item
     async fn replay_graph_data_edits(
         &self,

--- a/layercake-server/src/graphql/mutations/story.rs
+++ b/layercake-server/src/graphql/mutations/story.rs
@@ -34,6 +34,11 @@ impl StoryMutation {
                 ))
             })?;
 
+        let enabled_graph_ids_json =
+            serde_json::to_string(&input.enabled_graph_ids.unwrap_or_default()).map_err(|e| {
+                StructuredError::bad_request(format!("Failed to serialize enabled_graph_ids: {}", e))
+            })?;
+
         let layer_config_json = serde_json::to_string(&input.layer_config.unwrap_or_default())
             .map_err(|e| {
                 StructuredError::bad_request(format!("Failed to serialize layer_config: {}", e))
@@ -45,6 +50,7 @@ impl StoryMutation {
             description: Set(input.description),
             tags: Set(tags_json),
             enabled_dataset_ids: Set(enabled_dataset_ids_json),
+            enabled_graph_ids: Set(enabled_graph_ids_json),
             layer_config: Set(layer_config_json),
             created_at: Set(now),
             updated_at: Set(now),
@@ -100,6 +106,13 @@ impl StoryMutation {
                 ))
             })?;
             story.enabled_dataset_ids = Set(json);
+        }
+
+        if let Some(enabled_graph_ids) = input.enabled_graph_ids {
+            let json = serde_json::to_string(&enabled_graph_ids).map_err(|e| {
+                StructuredError::bad_request(format!("Failed to serialize enabled_graph_ids: {}", e))
+            })?;
+            story.enabled_graph_ids = Set(json);
         }
 
         if let Some(layer_config) = input.layer_config {

--- a/layercake-server/src/graphql/queries/mod.rs
+++ b/layercake-server/src/graphql/queries/mod.rs
@@ -67,6 +67,20 @@ impl Query {
         Ok(project.map(Project::from))
     }
 
+    /// Export a full project (datasets, plan DAG, stories, sequences, layers)
+    /// as a JSON string — for snapshotting a session or reproducing a bug.
+    #[graphql(name = "exportProject")]
+    async fn export_project(&self, ctx: &Context<'_>, id: i32) -> Result<String> {
+        let context = ctx.data::<GraphQLContext>()?;
+        let actor = context.actor_for_request(ctx).await;
+        let value = context
+            .app
+            .export_project_json(&actor, id)
+            .await
+            .map_err(crate::graphql::errors::core_error_to_graphql_error)?;
+        serde_json::to_string(&value).map_err(|e| e.into())
+    }
+
     async fn graph_summary(&self, ctx: &Context<'_>, dataset_id: i32) -> Result<GraphSummary> {
         let context = ctx.data::<GraphQLContext>()?;
         let summary = context
@@ -166,6 +180,25 @@ impl Query {
         let sequence = sequences::Entity::find_by_id(id).one(&context.db).await?;
 
         Ok(sequence.map(Sequence::from))
+    }
+
+    /// Build a story's sequence render context and return it as a JSON string,
+    /// without going through the Handlebars template. Lets a client render the
+    /// diagram itself, or inspect participants/steps/warnings directly.
+    #[graphql(name = "previewStoryContext")]
+    async fn preview_story_context(
+        &self,
+        ctx: &Context<'_>,
+        #[graphql(name = "projectId")] project_id: i32,
+        #[graphql(name = "storyId")] story_id: i32,
+    ) -> Result<String> {
+        let context = ctx.data::<GraphQLContext>()?;
+        let actor = context.actor_for_request(ctx).await;
+        context
+            .app
+            .preview_story_context_json(&actor, project_id, story_id)
+            .await
+            .map_err(crate::graphql::errors::core_error_to_graphql_error)
     }
 
     /// List project-wide layers (project palette)

--- a/layercake-server/src/graphql/types/story.rs
+++ b/layercake-server/src/graphql/types/story.rs
@@ -29,6 +29,10 @@ pub struct Story {
     pub tags: Vec<String>,
     #[graphql(name = "enabledDatasetIds")]
     pub enabled_dataset_ids: Vec<i32>,
+    /// Computed graph_data ids this story also sources edges from (GraphNode
+    /// outputs), in addition to raw datasets.
+    #[graphql(name = "enabledGraphIds")]
+    pub enabled_graph_ids: Vec<i32>,
     #[graphql(name = "layerConfig")]
     pub layer_config: Vec<StoryLayerConfig>,
     #[graphql(name = "createdAt")]
@@ -42,6 +46,8 @@ impl From<stories::Model> for Story {
         let tags: Vec<String> = serde_json::from_str(&model.tags).unwrap_or_default();
         let enabled_dataset_ids: Vec<i32> =
             serde_json::from_str(&model.enabled_dataset_ids).unwrap_or_default();
+        let enabled_graph_ids: Vec<i32> =
+            serde_json::from_str(&model.enabled_graph_ids).unwrap_or_default();
         let layer_config: Vec<StoryLayerConfig> =
             serde_json::from_str(&model.layer_config).unwrap_or_default();
 
@@ -52,6 +58,7 @@ impl From<stories::Model> for Story {
             description: model.description,
             tags,
             enabled_dataset_ids,
+            enabled_graph_ids,
             layer_config,
             created_at: model.created_at,
             updated_at: model.updated_at,
@@ -110,6 +117,8 @@ pub struct CreateStoryInput {
     pub tags: Option<Vec<String>>,
     #[graphql(name = "enabledDatasetIds")]
     pub enabled_dataset_ids: Option<Vec<i32>>,
+    #[graphql(name = "enabledGraphIds")]
+    pub enabled_graph_ids: Option<Vec<i32>>,
     #[graphql(name = "layerConfig")]
     pub layer_config: Option<Vec<StoryLayerConfig>>,
 }
@@ -121,6 +130,8 @@ pub struct UpdateStoryInput {
     pub tags: Option<Vec<String>>,
     #[graphql(name = "enabledDatasetIds")]
     pub enabled_dataset_ids: Option<Vec<i32>>,
+    #[graphql(name = "enabledGraphIds")]
+    pub enabled_graph_ids: Option<Vec<i32>>,
     #[graphql(name = "layerConfig")]
     pub layer_config: Option<Vec<StoryLayerConfig>>,
 }


### PR DESCRIPTION
Implements the deferred items from the tool-review-001 uplift (per follow-up direction). Feature requests that are larger/UI-heavy are filed as issues (#82–#86).

## F1 — `api info` live-port detection (`8a610327`)
Probes `/health` at the requested address, reports reachability + the live server version, and — if the port isn't answering — scans common local ports and hints `try --port N`. Kills the "wrong port" trap.

## Rec4 — schema tooling (`b4664072`)
`layercake schema type <Name>` (one type's SDL) and `--only-inputs` / `--only-mutations` filters on `schema dump`, via a small SDL block parser.

## F6 — `pruneOrphanedGraphs` + lifecycle docs (`2fd51015`)
`GraphDataService::prune_orphaned_graphs` deletes computed graphs whose `dag_node_id` no longer maps to a live plan node (FK-safe cascade); exposed as the `pruneOrphanedGraphs(projectId): [Int!]!` mutation. Computed-graph lifecycle documented in the node-types guide (pairs with `layercake doctor`).

## FR5/FR6 — export + preview endpoints (`3f22f62b`)
- `exportProject(id): String` — full project dump (project, datasets, plans, plan DAG nodes/edges, stories, sequences, layers) for snapshot/repro.
- `previewStoryContext(projectId, storyId): String` — the built `SequenceStoryContext` JSON (participants/steps/warnings) without the Handlebars template.

## F7 — GraphNode sourcing made real (`dc59f5ba`)
The StoryNode DAG upstream was decorative. New `stories.enabled_graph_ids` (migration + entity + GraphQL) lets a story source edges from a **computed graph** (a GraphNode's merged output), not just raw datasets. `build_graph_data_context` loads a computed graph into the same context shape; `SequenceEdgeRef.datasetId` may now be a dataset id OR a graph id. Frontend picker for computed graphs is filed as a follow-up (#86).

## Verification
188 core lib tests + server tests pass; workspace builds. Each item has a test (F1 manual + build, prune-only-orphans, computed-graph sourcing, exportProject end-to-end).

## Filed as issues (not built)
#82 renameNode, #83 dataset diff, #84 executePlan diagnostics, #85 palette presets + WCAG, #86 frontend sequence-authoring + computed-graph picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)