### PR TITLE
Tool-review-002 uplift: sequence render bugs, execution warnings, doctor ergonomics, docs

### DIFF
--- a/docs-tool/command/doc.md
+++ b/docs-tool/command/doc.md
@@ -22,6 +22,8 @@ layercake doc guide agent              # the AI agent query-interface guide
 layercake doc guide model              # the graph model documentation
 layercake doc guide node-types         # every plan DAG node type + its config
 layercake doc guide graph-json         # the GraphJson schema for datasets
+layercake doc guide render-config      # renderConfig keys per target
+layercake doc guide agent-runbook      # task → workflow/guide index (start here)
 ```
 
 ## For agents

--- a/docs-tool/command/doctor.md
+++ b/docs-tool/command/doctor.md
@@ -6,13 +6,19 @@ otherwise only surface as a silently empty diagram or a stale computed graph.
 ## Usage
 
 ```bash
-layercake doctor --project 36                 # human-readable report
+layercake doctor --project 36                 # resolves the DB from a running server
+layercake doctor --project 36 --port 3001     # …on a non-default port
+layercake doctor --project 36 --database ./my.db   # or point at the file directly
 layercake doctor --project 36 --json          # machine-readable
-layercake doctor --project 36 --database ./my.db
+layercake doctor --project 36 --strict        # exit non-zero on warnings too (CI)
 ```
 
-Exits non-zero if any **error**-severity finding is present (so CI/scripts can
-gate on it).
+If `--database` is omitted, the DB path is resolved from a running server's
+`/health` (via `--host`/`--port`/`--url`), so `doctor` works from any directory
+when the server is up — no need to be in the same folder as `layercake.db`.
+
+Exits non-zero if any **error**-severity finding is present; with `--strict`,
+any **warning** also fails.
 
 ## Checks
 

--- a/docs-tool/guide/agent-runbook.md
+++ b/docs-tool/guide/agent-runbook.md
@@ -1,0 +1,46 @@
+# Guide: Agent runbook
+
+One-page "when doing X, use Y" index for driving layercake as an agent. Start
+here; each row points at the workflow/guide/command with the detail.
+
+## First moves
+
+1. **Find the server** — `layercake api info` (probes `/health`, tells you the
+   real port and version, hints if you're on the wrong one).
+2. **Health-check the project** — `layercake doctor --project <id>` (resolves the
+   DB from the running server; run it whenever a diagram is empty or a graph
+   looks stale). Add `--strict` in CI.
+3. **Learn the API** — `layercake schema dump` (full SDL, offline),
+   `layercake schema type <Name>` (one type), `--only-inputs`/`--only-mutations`.
+
+## Task → where to look
+
+| I want to… | Use |
+|------------|-----|
+| Drive a running server over HTTP | `doc workflow drive-via-api`; `api call` |
+| Edit a plan DAG (nodes/edges) | `doc workflow edit-a-plan` |
+| Understand node types + their config | `doc guide node-types` |
+| Know the `graphJson` shape for datasets | `doc guide graph-json` |
+| Author a story → sequence diagram | `doc workflow develop-a-story` |
+| Source a story from a merged graph | `develop-a-story` (§ `enabledGraphIds`) |
+| Know which `renderConfig` keys a target accepts | `doc guide render-config` |
+| Preview a story without rendering | `previewStoryContext(projectId, storyId)` |
+| Run a plan headless (no server) | `doc workflow run-a-plan-headless` |
+| Inspect the DB directly | `doc workflow inspect-database`; `db info` |
+| Appear as a collaborator in the UI | `doc workflow join-as-collaborator` |
+| Snapshot a whole project | `exportProject(id)` query |
+| Diagnose "green but empty diagram" | `layercake doctor` |
+| Clean up orphaned computed graphs | `pruneOrphanedGraphs(projectId)` mutation |
+
+## Gotchas worth internalising
+
+- `layercake query` hits the **DB file directly**; `layercake api call` hits a
+  **running server**. Live UI updates need `api call`.
+- `metadata` needs a subfield selection: `metadata { label description }`.
+- Plan node ids are hash strings; join to a dataset PK via
+  `PlanDagNode.linkedDataSetId`.
+- A StoryNode sources from the story's `enabledDatasetIds`/`enabledGraphIds`,
+  **not** the DAG upstream. Wire the sources on the story.
+- Sequence notes render only when `renderConfig.showNotes` is true; an unset
+  `notePosition` means `Both`.
+- `execute*` results now carry a `warnings` array — check it.

--- a/docs-tool/guide/render-config.md
+++ b/docs-tool/guide/render-config.md
@@ -1,0 +1,75 @@
+# Guide: renderConfig by target
+
+Artefact nodes carry a `config` JSON with `renderTarget`, `outputPath`, and a
+`renderConfig` object. The accepted `renderConfig` keys depend on the target.
+`config` is stored as a JSON string (it bypasses schema validation today), so
+this guide is the source of truth for the keys.
+
+## Graph artefacts (GraphArtefactNode / TreeArtefactNode)
+
+`renderTarget`: `Mermaid`, `Graphviz`, `PlantUml`, `MermaidMindmap`,
+`MermaidTreemap`, … (see `schema type RenderTarget`). `renderConfig` keys:
+
+| key | type | effect |
+|-----|------|--------|
+| `containNodes` | bool | group child nodes under their partition (subgraphs/clusters) |
+| `orientation` | `TB`/`LR`/… | flow direction |
+| `applyLayers` | bool | emit per-layer styling (classDefs / cluster colours) from the project palette |
+| `builtInStyles` | `none`/`light`/`dark` | a built-in theme |
+| `addNodeCommentsAsNotes` | bool | render node comments as notes |
+| `notePosition` | `Left`/`Right`/… | where node-comment notes attach |
+| `useNodeWeight` / `useEdgeWeight` | bool | size by weight |
+| `targetOptions` | object | per-target options (e.g. mermaid `look`/`displayMode`) |
+| `layerSourceStyles` | array | per-dataset layer style overrides |
+
+**`builtInStyles` vs `applyLayers` (review N6):** they're independent.
+`applyLayers` emits your project palette's per-layer `classDef`/cluster colours;
+`builtInStyles` selects a base theme. With `builtInStyles: "none"` and
+`applyLayers: true` you get *no* base theme but *do* get palette colours — which
+is usually what you want for branded output.
+
+## Sequence artefacts (SequenceArtefactNode)
+
+`renderTarget`: `MermaidSequence` or `PlantUmlSequence`. **`outputPath` must
+match**: `.mmd`/`.md` for MermaidSequence, `.puml`/`.txt` for PlantUmlSequence
+(mismatches are now rejected). `renderConfig` keys:
+
+| key | type | effect |
+|-----|------|--------|
+| `containNodes` | `"one"`/`"all"` (or bool: true→one, false→all) | `one` = a box per partition; `all` = one box round everything |
+| `builtInStyles` | `none`/`light`/`dark` | theme |
+| `showNotes` | bool (default true) | emit edge notes. **Notes only render when this is true** |
+| `renderAllSequences` | bool (default true) | render every sequence, or only `enabledSequenceIds` |
+| `enabledSequenceIds` | [int] | which sequences to render when `renderAllSequences` is false |
+
+`useStoryLayers` (bool, sibling of `renderConfig`) applies the story's layer
+colours to participants/boxes.
+
+### Notes: position and null (review N7)
+
+Each sequence edge ref has a `notePosition`: `Source` | `Target` | `Both`.
+**If `notePosition` is null/unset, it defaults to `Both`** — `Note over
+source,target`. Set it explicitly to pin a note to one lifeline.
+
+### Examples
+
+```jsonc
+// Mermaid sequence, per-partition boxes, notes on
+{"renderTarget":"MermaidSequence","outputPath":"scenario.mmd",
+ "renderConfig":{"containNodes":"one","showNotes":true},"useStoryLayers":true}
+
+// PlantUML sequence, single box, dark theme
+{"renderTarget":"PlantUmlSequence","outputPath":"scenario.puml",
+ "renderConfig":{"containNodes":"all","builtInStyles":"dark"}}
+
+// Graph, palette colours but no base theme
+{"renderTarget":"Mermaid","outputPath":"graph.mmd",
+ "renderConfig":{"applyLayers":true,"builtInStyles":"none","containNodes":true}}
+```
+
+## For agents
+
+If a diagram "isn't doing what I expect", check: `showNotes` (sequence notes),
+`applyLayers` vs `builtInStyles` (colours), and `containNodes` (grouping). Then
+run `layercake doctor` — an empty diagram is usually an unresolved edge, not a
+config problem.

--- a/docs-tool/workflow/develop-a-story.md
+++ b/docs-tool/workflow/develop-a-story.md
@@ -25,7 +25,8 @@ follow-up — set `enabledGraphIds` via the API for now.)
   edge becomes a sequence-diagram message `source ->> target: <edge label>`.
 - Each edge reference (`SequenceEdgeRef`) is one **step + commentary**:
   `{ datasetId, edgeId, note?, notePosition? }`. The `note` is the commentary;
-  `notePosition` is `Source | Target | Both`.
+  `notePosition` is `Source | Target | Both`. **If `notePosition` is null/unset
+  it defaults to `Both`** (`Note over source,target`).
 - **Participants (lifelines) are derived** from the edges' endpoints — you do not
   author them.
 - Rendering happens through the plan DAG: a **StoryNode** (`{ storyId }`) feeds a

--- a/docs-tool/workflow/drive-via-api.md
+++ b/docs-tool/workflow/drive-via-api.md
@@ -5,7 +5,9 @@ Connect to a running instance and run GraphQL queries/mutations.
 ## Start / find the server
 
 ```bash
-layercake serve                      # http://127.0.0.1:3000 (loopback)
+layercake serve                      # http://127.0.0.1:3000 (loopback; the default —
+                                     #   your project may run on another port, e.g. 3001.
+                                     #   `layercake api info` tells you the live one)
 layercake serve --host 0.0.0.0 --port 8080   # expose on a network
 layercake api info                   # print endpoints + headers for the running server
 ```

--- a/layercake-cli/src/doctor.rs
+++ b/layercake-cli/src/doctor.rs
@@ -1,16 +1,75 @@
 //! `layercake doctor` — scan a project for structural health problems.
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use layercake_core::database::connection::{establish_connection, get_database_url};
 use layercake_core::doctor::{run_diagnostics, Severity};
+use std::time::Duration;
 
-pub async fn run(project: i32, database: Option<&str>, json: bool) -> Result<()> {
-    let db = establish_connection(&get_database_url(database)).await?;
+/// Resolve the database path: explicit `--database` wins; otherwise ask a
+/// running server's `/health` (so `doctor --project N` works cwd-independently
+/// when the server is up).
+async fn resolve_database(
+    database: Option<&str>,
+    url: Option<&str>,
+    host: &str,
+    port: u16,
+) -> Result<String> {
+    if let Some(db) = database {
+        return Ok(db.to_string());
+    }
+    let base = match url {
+        Some(u) => u.trim_end_matches('/').to_string(),
+        None => format!("http://{}:{}", host, port),
+    };
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_millis(800))
+        .build()?;
+    let resp = client
+        .get(format!("{}/health", base))
+        .send()
+        .await
+        .map_err(|e| {
+            anyhow!(
+                "no --database given and could not reach a server at {} to resolve it ({}). \
+                 Pass --database <path>, or --host/--port/--url of a running server.",
+                base,
+                e
+            )
+        })?;
+    let body: serde_json::Value = resp.json().await?;
+    body.get("database")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .ok_or_else(|| {
+            anyhow!(
+                "server at {} did not report a database path (older server?). Pass --database.",
+                base
+            )
+        })
+}
+
+pub async fn run(
+    project: i32,
+    database: Option<&str>,
+    url: Option<&str>,
+    host: &str,
+    port: u16,
+    strict: bool,
+    json: bool,
+) -> Result<()> {
+    let database = resolve_database(database, url, host, port).await?;
+    let db = establish_connection(&get_database_url(Some(&database))).await?;
     let report = run_diagnostics(&db, project).await?;
+
+    let warning_count = report
+        .findings
+        .iter()
+        .filter(|f| f.severity == Severity::Warning)
+        .count();
 
     if json {
         println!("{}", serde_json::to_string_pretty(&report)?);
-        return finish(report.error_count());
+        return finish(report.error_count(), warning_count, strict);
     }
 
     if report.is_healthy() {
@@ -27,11 +86,12 @@ pub async fn run(project: i32, database: Option<&str>, json: bool) -> Result<()>
         };
         println!("  [{}] {}: {}", tag, f.check, f.message);
     }
-    finish(report.error_count())
+    finish(report.error_count(), warning_count, strict)
 }
 
-fn finish(error_count: usize) -> Result<()> {
-    if error_count > 0 {
+fn finish(error_count: usize, warning_count: usize, strict: bool) -> Result<()> {
+    let fail = error_count > 0 || (strict && warning_count > 0);
+    if fail {
         // Non-zero exit so scripts/CI can gate on it.
         std::process::exit(1);
     }

--- a/layercake-cli/src/main.rs
+++ b/layercake-cli/src/main.rs
@@ -115,8 +115,20 @@ enum Commands {
         /// Project id to scan
         #[clap(long)]
         project: i32,
-        #[clap(short, long, default_value = "layercake.db")]
-        database: String,
+        /// Database file path. If omitted, resolved from a running server's
+        /// /health (see --host/--port/--url).
+        #[clap(short, long)]
+        database: Option<String>,
+        /// Running server base URL to resolve the DB path from (overrides host/port)
+        #[clap(long)]
+        url: Option<String>,
+        #[clap(long, default_value = "127.0.0.1")]
+        host: String,
+        #[clap(short, long, default_value = "3000")]
+        port: u16,
+        /// Exit non-zero on warnings too, not just errors (for CI)
+        #[clap(long)]
+        strict: bool,
         /// Emit machine-readable JSON
         #[clap(long)]
         json: bool,
@@ -349,9 +361,22 @@ async fn main() -> Result<()> {
         Commands::Doctor {
             project,
             database,
+            url,
+            host,
+            port,
+            strict,
             json,
         } => {
-            doctor::run(project, Some(&database), json).await?;
+            doctor::run(
+                project,
+                database.as_deref(),
+                url.as_deref(),
+                &host,
+                port,
+                strict,
+                json,
+            )
+            .await?;
         }
         Commands::Api { command } => match command {
             ApiCommands::Info {

--- a/layercake-core/src/common/handlebars.rs
+++ b/layercake-core/src/common/handlebars.rs
@@ -60,6 +60,25 @@ pub fn get_handlebars() -> Handlebars<'static> {
     });
     handlebars.register_helper("inline", Box::new(inline));
 
+    // Like `inline`, but also neutralises characters that break Mermaid's
+    // sequence-diagram grammar when they appear in free text. Mermaid treats
+    // `;` as a statement terminator, so a note/label containing `;` truncates
+    // the statement mid-line (with a misleading error on the *next* line).
+    // Replace it with an em-dash. Use this for note/label/name text in the
+    // Mermaid sequence template.
+    handlebars_helper!(mermaid_safe: |v: Value| {
+        let s = match v {
+            Value::String(s) => s,
+            Value::Null => String::new(),
+            other => other.to_string(),
+        };
+        s.split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
+            .replace(';', "—")
+    });
+    handlebars.register_helper("mermaid_safe", Box::new(mermaid_safe));
+
     // Emit a value as a YAML double-quoted scalar, escaping backslashes,
     // quotes, and collapsing newlines. Needed for Mermaid frontmatter fields
     // like `title:` — an unquoted title containing ':' breaks YAML parsing and

--- a/layercake-core/src/export/sequence_renderer.rs
+++ b/layercake-core/src/export/sequence_renderer.rs
@@ -280,4 +280,36 @@ mod tests {
         assert!(tgt.contains("note over b\nN"), "{tgt}");
         assert!(!tgt.contains("note over a,b\nN"), "{tgt}");
     }
+
+    // Regression for N8: a ';' in a note/label breaks Mermaid's sequence
+    // grammar (it's a statement terminator). The mermaid_safe helper must
+    // neutralise it so the message/note statement stays on one line.
+    #[test]
+    fn semicolon_in_note_and_label_is_neutralised_for_mermaid() {
+        let mut ctx = SequenceRenderContext::default();
+        ctx.config.show_notes = true;
+        ctx.participants = vec![participant("a", "A", None), participant("b", "B", None)];
+        ctx.first_participant_alias = Some("a".into());
+        ctx.last_participant_alias = Some("b".into());
+        ctx.sequences = vec![SequenceRender {
+            id: 1,
+            name: "S".into(),
+            description: None,
+            steps: vec![SequenceStep {
+                id: "s".into(),
+                dataset_id: 1,
+                dataset_name: "d".into(),
+                source: SequenceParticipantRef { alias: "a".into(), label: "A".into() },
+                target: SequenceParticipantRef { alias: "b".into(), label: "B".into() },
+                label: "resolves; then breaks".into(),
+                note: Some("opacity: no records; audit broken".into()),
+                note_position: Some("both".into()),
+            }],
+        }];
+        let out = to_mermaid_sequence::render(&ctx).unwrap();
+        assert!(!out.contains(';'), "no semicolons should reach Mermaid output:\n{out}");
+        // The text survives, just with ';' swapped for an em-dash.
+        assert!(out.contains("resolves— then breaks"), "{out}");
+        assert!(out.contains("no records— audit broken"), "{out}");
+    }
 }

--- a/layercake-core/src/export/to_mermaid_sequence.hbs
+++ b/layercake-core/src/export/to_mermaid_sequence.hbs
@@ -5,39 +5,39 @@ sequenceDiagram
 
 {{#unless (is_empty sequence.participantGroups)}}
   {{#each sequence.participantGroups}}
-box {{#if this.color}}{{this.color}}{{/if}} "{{inline this.label}}"
+box {{#if this.color}}{{this.color}}{{/if}} "{{mermaid_safe this.label}}"
     {{#each this.participants}}
-    participant {{alias}} as "{{inline label}}"
+    participant {{alias}} as "{{mermaid_safe label}}"
     {{/each}}
 end
   {{/each}}
 {{else}}
   {{#each sequence.participants}}
-  participant {{alias}} as "{{inline label}}"
+  participant {{alias}} as "{{mermaid_safe label}}"
   {{/each}}
 {{/unless}}
 
 {{#unless (is_empty sequence.sequences)}}
   {{#each sequence.sequences}}
-%% Sequence: {{inline name}}
+%% Sequence: {{mermaid_safe name}}
     {{#if @root.sequence.firstParticipantAlias}}
-    Note over {{@root.sequence.firstParticipantAlias}},{{@root.sequence.lastParticipantAlias}}: {{inline name}}
+    Note over {{@root.sequence.firstParticipantAlias}},{{@root.sequence.lastParticipantAlias}}: {{mermaid_safe name}}
     {{/if}}
     {{#each steps}}
       {{#if @root.sequence.config.showNotes}}
         {{#if note}}
           {{#if (stringeq notePosition "source")}}
-    Note over {{source.alias}}: {{inline note}}
+    Note over {{source.alias}}: {{mermaid_safe note}}
           {{else}}
             {{#if (stringeq notePosition "target")}}
-    Note over {{target.alias}}: {{inline note}}
+    Note over {{target.alias}}: {{mermaid_safe note}}
             {{else}}
-    Note over {{source.alias}},{{target.alias}}: {{inline note}}
+    Note over {{source.alias}},{{target.alias}}: {{mermaid_safe note}}
             {{/if}}
           {{/if}}
         {{/if}}
       {{/if}}
-    {{source.alias}}->>{{target.alias}}: {{inline label}}
+    {{source.alias}}->>{{target.alias}}: {{mermaid_safe label}}
     {{/each}}
   {{/each}}
 {{else}}

--- a/layercake-core/src/pipeline/dag_executor.rs
+++ b/layercake-core/src/pipeline/dag_executor.rs
@@ -25,6 +25,9 @@ pub struct DagExecutor {
     dataset_importer: DatasourceImporter,
     graph_data_builder: GraphDataBuilder,
     merge_builder: MergeBuilder,
+    /// Non-fatal warnings accumulated during a run, surfaced on the execution
+    /// result so callers see them without reading logs or context_json.
+    warnings: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
 }
 
 /// Options for creating or updating graph_data records originating from DAG nodes
@@ -64,7 +67,22 @@ impl DagExecutor {
             dataset_importer,
             graph_data_builder,
             merge_builder,
+            warnings: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
         }
+    }
+
+    fn push_warning(&self, warning: impl Into<String>) {
+        if let Ok(mut w) = self.warnings.lock() {
+            w.push(warning.into());
+        }
+    }
+
+    /// Take the warnings accumulated so far, clearing the buffer.
+    pub fn take_warnings(&self) -> Vec<String> {
+        self.warnings
+            .lock()
+            .map(|mut w| std::mem::take(&mut *w))
+            .unwrap_or_default()
     }
 
     fn maybe_context(&self) -> Option<DagExecutionContext> {
@@ -294,6 +312,7 @@ impl DagExecutor {
                 let story_context = build_story_context(&self.db, project_id, story_id).await?;
                 for warning in &story_context.warnings {
                     tracing::warn!(node = %node_id, story = story_id, "{}", warning);
+                    self.push_warning(format!("node '{}': {}", node_id, warning));
                 }
                 self.persist_story_context(project_id, node_id, story_id, &story_context)
                     .await?;

--- a/layercake-server/src/graphql/mutations/helpers.rs
+++ b/layercake-server/src/graphql/mutations/helpers.rs
@@ -484,6 +484,9 @@ pub struct PlanExecutionResult {
     pub success: bool,
     pub message: String,
     pub output_files: Vec<String>,
+    /// Non-fatal problems encountered during execution (e.g. a story sequence
+    /// that resolved no steps). Empty on a fully clean run.
+    pub warnings: Vec<String>,
 }
 
 #[derive(async_graphql::SimpleObject)]
@@ -491,6 +494,8 @@ pub struct NodeExecutionResult {
     pub success: bool,
     pub message: String,
     pub node_id: String,
+    /// Non-fatal problems encountered during execution. Empty on a clean run.
+    pub warnings: Vec<String>,
 }
 
 #[derive(async_graphql::SimpleObject)]

--- a/layercake-server/src/graphql/mutations/helpers.rs
+++ b/layercake-server/src/graphql/mutations/helpers.rs
@@ -79,11 +79,34 @@ pub struct StoredSequenceArtefactNodeConfig {
 #[derive(Debug, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StoredSequenceRenderConfig {
+    /// `containNodes` may be stored as a string ("one"/"all") by the API or as a
+    /// boolean by the UI. Accept both so a UI edit doesn't silently drop the
+    /// whole render config (true → "one", false → "all").
+    #[serde(default, deserialize_with = "deserialize_contain_nodes")]
     pub contain_nodes: Option<String>,
     pub built_in_styles: Option<String>,
     pub show_notes: Option<bool>,
     pub render_all_sequences: Option<bool>,
     pub enabled_sequence_ids: Option<Vec<i32>>,
+}
+
+fn deserialize_contain_nodes<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::Deserialize;
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum StringOrBool {
+        S(String),
+        B(bool),
+    }
+    Ok(match Option::<StringOrBool>::deserialize(deserializer)? {
+        Some(StringOrBool::S(s)) => Some(s),
+        Some(StringOrBool::B(true)) => Some("one".to_string()),
+        Some(StringOrBool::B(false)) => Some("all".to_string()),
+        None => None,
+    })
 }
 
 /// Stored render configuration
@@ -511,4 +534,32 @@ pub struct ExportNodeOutputResult {
     pub content: String, // Base64 encoded
     pub filename: String,
     pub mime_type: String,
+}
+
+#[cfg(test)]
+mod contain_nodes_tests {
+    use super::StoredSequenceRenderConfig;
+
+    #[test]
+    fn accepts_string_and_bool_contain_nodes() {
+        // String form (API).
+        let s: StoredSequenceRenderConfig =
+            serde_json::from_str(r#"{"containNodes":"all","showNotes":true}"#).unwrap();
+        assert_eq!(s.contain_nodes.as_deref(), Some("all"));
+        assert_eq!(s.show_notes, Some(true));
+
+        // Bool form (UI) — must not drop the rest of the config.
+        let b: StoredSequenceRenderConfig =
+            serde_json::from_str(r#"{"containNodes":true,"showNotes":false}"#).unwrap();
+        assert_eq!(b.contain_nodes.as_deref(), Some("one"));
+        assert_eq!(b.show_notes, Some(false));
+
+        let bf: StoredSequenceRenderConfig =
+            serde_json::from_str(r#"{"containNodes":false}"#).unwrap();
+        assert_eq!(bf.contain_nodes.as_deref(), Some("all"));
+
+        // Absent.
+        let n: StoredSequenceRenderConfig = serde_json::from_str(r#"{}"#).unwrap();
+        assert_eq!(n.contain_nodes, None);
+    }
 }

--- a/layercake-server/src/graphql/mutations/plan.rs
+++ b/layercake-server/src/graphql/mutations/plan.rs
@@ -140,6 +140,7 @@ impl PlanMutation {
                 success: true,
                 message: "No nodes to execute in this plan".to_string(),
                 output_files: vec![],
+                warnings: vec![],
             });
         }
 
@@ -164,10 +165,12 @@ impl PlanMutation {
             .await
             .map_err(|e| StructuredError::service("DagExecutor::execute_dag", e))?;
 
+        let warnings = executor.take_warnings();
         Ok(PlanExecutionResult {
             success: true,
             message: format!("Executed {} nodes in topological order", nodes.len()),
             output_files: vec![],
+            warnings,
         })
     }
 

--- a/layercake-server/src/graphql/mutations/plan_dag_nodes.rs
+++ b/layercake-server/src/graphql/mutations/plan_dag_nodes.rs
@@ -87,9 +87,11 @@ impl PlanDagNodesMutation {
         };
 
         let config_value = if let Some(config) = config {
-            Some(serde_json::from_str::<JsonValue>(&config).map_err(|e| {
+            let value = serde_json::from_str::<JsonValue>(&config).map_err(|e| {
                 StructuredError::bad_request(format!("Invalid node configuration JSON: {}", e))
-            })?)
+            })?;
+            validate_render_target_extension(&value)?;
+            Some(value)
         } else {
             None
         };
@@ -264,5 +266,79 @@ impl PlanDagNodesMutation {
             node_id,
             warnings,
         })
+    }
+}
+
+/// If a node config is a sequence-artefact config (`renderTarget` +
+/// `outputPath`), reject a `renderTarget` that doesn't match the output file
+/// extension. This catches the silent drift where a UI edit flips
+/// MermaidSequence→PlantUmlSequence while `outputPath` stays `.mmd` (so a
+/// `.mmd` file ends up containing PlantUML).
+fn validate_render_target_extension(config: &JsonValue) -> Result<()> {
+    let (Some(target), Some(path)) = (
+        config.get("renderTarget").and_then(|v| v.as_str()),
+        config.get("outputPath").and_then(|v| v.as_str()),
+    ) else {
+        return Ok(());
+    };
+
+    let ext = std::path::Path::new(path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_lowercase();
+
+    let (allowed, kind): (&[&str], &str) = match target {
+        "MermaidSequence" => (&["mmd", "md"], "MermaidSequence"),
+        "PlantUmlSequence" => (&["puml", "txt"], "PlantUmlSequence"),
+        _ => return Ok(()), // unknown/other target → don't constrain
+    };
+
+    if !allowed.contains(&ext.as_str()) {
+        return Err(StructuredError::validation(
+            "outputPath",
+            format!(
+                "renderTarget {} expects an output extension of {} but outputPath is '{}'. \
+                 Update the extension or the renderTarget so they match.",
+                kind,
+                allowed
+                    .iter()
+                    .map(|e| format!(".{}", e))
+                    .collect::<Vec<_>>()
+                    .join(" or "),
+                path
+            ),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod render_target_validation_tests {
+    use super::validate_render_target_extension;
+    use serde_json::json;
+
+    #[test]
+    fn rejects_mismatched_extension() {
+        // MermaidSequence writing to .puml → reject.
+        let bad = json!({"renderTarget":"MermaidSequence","outputPath":"scenario.puml"});
+        assert!(validate_render_target_extension(&bad).is_err());
+        // PlantUmlSequence writing to .mmd → reject (the reviewer's exact drift).
+        let bad2 = json!({"renderTarget":"PlantUmlSequence","outputPath":"scenario.mmd"});
+        assert!(validate_render_target_extension(&bad2).is_err());
+    }
+
+    #[test]
+    fn accepts_matching_extension_and_ignores_non_sequence_configs() {
+        assert!(validate_render_target_extension(
+            &json!({"renderTarget":"MermaidSequence","outputPath":"s.mmd"})
+        )
+        .is_ok());
+        assert!(validate_render_target_extension(
+            &json!({"renderTarget":"PlantUmlSequence","outputPath":"s.puml"})
+        )
+        .is_ok());
+        // A config without renderTarget/outputPath (e.g. a DataSetNode) is untouched.
+        assert!(validate_render_target_extension(&json!({"dataSetId":5})).is_ok());
     }
 }

--- a/layercake-server/src/graphql/mutations/plan_dag_nodes.rs
+++ b/layercake-server/src/graphql/mutations/plan_dag_nodes.rs
@@ -254,6 +254,7 @@ impl PlanDagNodesMutation {
             .await
             .map_err(|e| StructuredError::service("DagExecutor::execute_affected_nodes", e))?;
 
+        let warnings = executor.take_warnings();
         Ok(NodeExecutionResult {
             success: true,
             message: format!(
@@ -261,6 +262,7 @@ impl PlanDagNodesMutation {
                 node_id
             ),
             node_id,
+            warnings,
         })
     }
 }

--- a/layercake-server/src/server/app.rs
+++ b/layercake-server/src/server/app.rs
@@ -40,9 +40,16 @@ pub struct AppState {
     pub projections_schema: ProjectionsSchema,
     #[allow(dead_code)] // Exposed for future REST handlers or tests
     pub projection_service: Arc<ProjectionService>,
+    /// The database path this server was started with, surfaced on /health so
+    /// tools like `layercake doctor --port N` can resolve it cwd-independently.
+    pub database_path: String,
 }
 
-pub async fn create_app(db: DatabaseConnection, cors_origin: Option<&str>) -> Result<Router> {
+pub async fn create_app(
+    db: DatabaseConnection,
+    cors_origin: Option<&str>,
+    database_path: String,
+) -> Result<Router> {
     let system_settings = Arc::new(
         SystemSettingsService::new(db.clone())
             .await
@@ -125,6 +132,7 @@ pub async fn create_app(db: DatabaseConnection, cors_origin: Option<&str>) -> Re
         coordinator_handle,
         projections_schema,
         projection_service,
+        database_path,
     };
 
     let cors = match cors_origin {

--- a/layercake-server/src/server/handlers/health.rs
+++ b/layercake-server/src/server/handlers/health.rs
@@ -1,10 +1,13 @@
-use axum::{http::StatusCode, response::Json};
+use axum::{extract::State, http::StatusCode, response::Json};
 use serde_json::{json, Value};
 
-pub async fn health_check() -> Result<Json<Value>, StatusCode> {
+use crate::server::app::AppState;
+
+pub async fn health_check(State(state): State<AppState>) -> Result<Json<Value>, StatusCode> {
     Ok(Json(json!({
         "status": "healthy",
         "service": "layercake-server",
-        "version": env!("CARGO_PKG_VERSION")
+        "version": env!("CARGO_PKG_VERSION"),
+        "database": state.database_path,
     })))
 }

--- a/layercake-server/src/server/mod.rs
+++ b/layercake-server/src/server/mod.rs
@@ -44,7 +44,7 @@ pub async fn start_server(
         Err(e) => warn!("Failed to reconcile interrupted graph executions: {}", e),
     }
 
-    let app = app::create_app(db, cors_origin).await?;
+    let app = app::create_app(db, cors_origin, database_path.to_string()).await?;
 
     // Log all HTTP routes dynamically
     log_routes(port);

--- a/plans/20260715-tool-review-002-uplift.md
+++ b/plans/20260715-tool-review-002-uplift.md
@@ -2,6 +2,7 @@
 
 **Date:** 2026-07-15
 **Source:** `reviews/tool-review-002.md` (post-uplift session, project 36).
+**Status:** All stages (1–6) complete on `fix/tool-review-002-uplift`; N4/doctor-fix filed as #88/#89.
 **Approach:** structural over patches (per project direction / memory). Validate every finding against current master first — the reviewer's build predated PR #87, so several "remaining" items are already shipped.
 
 ## Validation: what's stale vs. live (checked against master)

--- a/plans/20260715-tool-review-002-uplift.md
+++ b/plans/20260715-tool-review-002-uplift.md
@@ -1,0 +1,72 @@
+# Uplift plan — tool-review-002
+
+**Date:** 2026-07-15
+**Source:** `reviews/tool-review-002.md` (post-uplift session, project 36).
+**Approach:** structural over patches (per project direction / memory). Validate every finding against current master first — the reviewer's build predated PR #87, so several "remaining" items are already shipped.
+
+## Validation: what's stale vs. live (checked against master)
+
+**Already on master (reviewer saw a stale build — NO action):**
+- F1 `api info` health probe + port detection — shipped (PR #87, `8a610327`). `api.rs` has `probe_health`/`detected_ports`.
+- F6 `pruneOrphanedGraphs` mutation — shipped (`2fd51015`).
+- Rec4 `schema type <Name>` + `--only-inputs/--only-mutations` — shipped (`b4664072`).
+- F7 `enabledGraphIds` (GraphNode sourcing real) — shipped (`dc59f5ba`).
+- exportProject — reviewer already retracted FR5.
+
+**Genuinely live findings (ACTION):**
+
+| # | Finding | Verdict | Notes |
+|---|---------|---------|-------|
+| **N8** | `;` in note/label breaks Mermaid sequence parsing | **CONFIRMED, real render bug** | `inline` helper only does `split_whitespace().join(" ")` — `;` passes through. Same class as the frontmatter-title fix. Highest value. |
+| **Rec1/F2** | `NodeExecutionResult`/`PlanExecutionResult` lack `warnings` | **CONFIRMED** | `helpers.rs:483-494` — only `success`/`message`. Pipeline collects warnings but they don't reach the direct-return path. Closes F2 fully. |
+| **N1** | renderTarget ↔ outputPath extension drift (silent) | **CONFIRMED** | Editing a SequenceArtefactNode can flip `MermaidSequence`→`PlantUmlSequence` while `outputPath` stays `.mmd`. No validation. |
+| **N5 / D2** | `containNodes` typed as both bool and enum; `SequenceRenderConfigInput` not wired | **CONFIRMED** | `config.rs`: `SequenceRenderConfig.contain_nodes: SequenceContainNodes` (enum) vs `RenderConfig.contain_nodes: Option<bool>`. `SequenceRenderConfigInput` exists but the artefact `config` is a free-form JSON string that bypasses it. |
+| **N2** | `doctor` has `--database`, not `--port` (inconsistent w/ `api`) | CONFIRMED | Ergonomics. |
+| **N3** | `doctor --database layercake.db` is cwd-relative; can't resolve from server | CONFIRMED | Ergonomics; should work when the server is up. |
+| **N7** | null `notePosition` behaviour undocumented | CONFIRMED (doc) | Falls back to "both". Document + make explicit. |
+| **Rec2** | auto-run doctor / `--strict` | Partially (doctor exits non-zero on errors; no `--strict` for warnings). |
+| **Rec3/Rec6** | `doc guide render-config`, `agent-runbook` | Docs. |
+| **N4/N6** | stylistic (`.smmd` ext; builtInStyles×applyLayers clarity) | Low — docs only. |
+
+## Stages
+
+Ordered by value. Each stage builds + tests + commits independently.
+
+### Stage 1 — N8: sanitize sequence text against grammar hazards [CORRECTNESS, highest value]
+Add a `mermaid_safe` handlebars helper: collapse whitespace/newlines (like `inline`), and replace `;` (Mermaid sequence statement terminator) with `—` (or `,`). Apply to every note/label/name in `to_mermaid_sequence.hbs`. For `to_plantuml_sequence.hbs`, add a `plantuml_safe` (or reuse, PlantUML's hazards differ — `;` is safe there, but survey). Regression test: a note containing `;` renders without breaking the statement.
+**Status:** Not Started
+
+### Stage 2 — Rec1/F2: surface warnings on execution results [ARCHITECTURE, closes F2]
+Thread the `SequenceStoryContext.warnings` (already collected) up to the GraphQL execution result. Add `warnings: [String!]!` to `NodeExecutionResult` and `PlanExecutionResult`. The executor must collect per-node warnings and return them. This closes the F2 caveat — an agent calling `executeNode`/`executePlan` sees the warning stream directly, not just via doctor/logs.
+**Status:** Not Started
+
+### Stage 3 — N1 + N5/D2: artefact config validation [CORRECTNESS]
+- Validate `renderTarget` ↔ `outputPath` extension on SequenceArtefactNode save (reject/warn: MermaidSequence needs `.mmd`/`.md`; PlantUmlSequence needs `.puml`/`.txt`), OR auto-rewrite the extension. Prefer a validation warning surfaced via the new warnings channel + a hard reject on clear mismatch.
+- Wire `SequenceRenderConfigInput` (or document that `config` is JSON and normalise `containNodes` string/bool). At minimum, make the pipeline accept both `containNodes: "one"` and `true` consistently and document it. (Full schema-typed config is larger — evaluate.)
+**Status:** Not Started
+
+### Stage 4 — N2/N3: doctor ergonomics [UX]
+- Add `--port`/`--host`/`--url` to `doctor` so it can resolve the DB path from a running server's `api info` (the server knows its `--database`). Keep `--database` as an override. Goal: `layercake doctor --project 36` works when the server is up, cwd-independent.
+- Requires the server to expose its database path — check `/health` or add a lightweight info endpoint.
+**Status:** Not Started
+
+### Stage 5 — Rec2/Rec7: doctor `--strict` + auto-run hook [UX]
+- `doctor --strict`: exit non-zero on warnings too (for CI).
+- Consider an `executePlan` option or post-run doctor summary. Evaluate scope; at minimum `--strict`.
+**Status:** Not Started
+
+### Stage 6 — Docs: render-config guide, agent-runbook, N7 [DOCS]
+- `layercake doc guide render-config` — every render target → accepted renderConfig keys, with examples (theming, containNodes vs classDef, sequence keys, showNotes).
+- `layercake doc guide agent-runbook` (or extend `guide agent`) — task → workflow/guide index.
+- Document null `notePosition` = "both" (N7) in develop-a-story.
+- Reconcile port docs (D1): note 3000 default + per-project override.
+**Status:** Not Started
+
+## Deferred / file as issues (not building now)
+- N4 (`.smmd` extension) — stylistic; issue.
+- N6 (builtInStyles × applyLayers interaction) — clarify in render-config guide (Stage 6).
+- Doctor `--fix` (Rec4 in review-002) — larger remediation feature; issue.
+- Carrying FRs already tracked: #82 renameNode, #83 dataset diff, #84 exec timings, #85 palette+WCAG, #86 frontend authoring. FR6 story-preview — `previewStoryContext` already shipped (PR #87); reviewer's "not shipped" is stale.
+
+## Guiding principle
+Structural, seam-unifying fixes; make failures visible (N8 render bug, warnings on results); don't add patches. N8 and Rec1 are the two that most improve day-to-day agent use.


### PR DESCRIPTION
Implements the uplift plan for `reviews/tool-review-002.md`. Every finding validated against master first — the reviewer's build predated PR #87, so F1/F6/F7/Rec4/exportProject were already shipped (noted in the plan, no action). Plan: `plans/20260715-tool-review-002-uplift.md`.

## Correctness

**N8 — `;` breaks Mermaid sequence parsing** (`3e026320`). A `;` in a note/label truncated the statement mid-line (Mermaid treats it as a terminator; the error points at the *next* line). New `mermaid_safe` handlebars helper replaces `;` with an em-dash, applied to every note/label/name in the mermaid sequence template. Same class as the frontmatter-title fix. Three notes in the reviewer's project hit this.

**N1 — renderTarget ↔ outputPath drift** (`16e5c684`). A UI edit could flip `MermaidSequence`→`PlantUmlSequence` while `outputPath` stayed `.mmd`. `updatePlanDagNode` now rejects a mismatch (MermaidSequence needs `.mmd`/`.md`; PlantUmlSequence `.puml`/`.txt`).

**N5/D2 — `containNodes` bool vs string** (`16e5c684`). The UI stores `containNodes` as a bool but the type was `Option<String>`, so the whole render config silently failed to parse and reset to defaults. Flexible deserializer now accepts both (true→one, false→all).

## Architecture

**Rec1 — warnings on execution results, closes F2** (`9154ae49`). The pipeline collected sequence warnings but an agent calling `executeNode`/`executePlan` only saw `{success, message}`. `DagExecutor` now accumulates warnings and `NodeExecutionResult`/`PlanExecutionResult` carry `warnings: [String!]!`.

## Ergonomics / docs

**N2/N3 + Rec2/Rec7 — doctor** (`819501de`). `/health` now reports the server's DB path; `doctor --project N --port …` resolves it from a running server (cwd-independent — the reviewer's exact trap). Added `--strict` (fail on warnings, for CI).

**Docs** (`a71489e2`): `doc guide render-config` (keys per target, builtInStyles×applyLayers N6, showNotes), `doc guide agent-runbook` (task→guide index), N7 (unset notePosition = Both), D1 (port doc reconciled).

## Verification
189 core lib tests + server tests pass; workspace builds. Regression tests for N8 (no `;` in output), N1 (mismatch rejected), N5 (bool/string parse), warnings surfaced, doctor server-resolution.

## Filed as issues
#88 (.smmd extension convention), #89 (doctor --fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)