### PR TITLE
Implement deferred feature requests (FR7, FR1, FR2, FR4, FR3a)

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -1,0 +1,73 @@
+# Dolt database (managed by Dolt, not git)
+dolt/
+dolt-access.lock
+
+# Runtime files
+bd.sock
+bd.sock.startlock
+sync-state.json
+last-touched
+.exclusive-lock
+
+# Daemon runtime (lock, log, pid)
+daemon.*
+
+# Interactions log (runtime, not versioned)
+interactions.jsonl
+
+# Push state (runtime, per-machine)
+push-state.json
+
+# Lock files (various runtime locks)
+*.lock
+
+# Credential key (encryption key for federation peer auth — never commit)
+.beads-credential-key
+
+# Local version tracking (prevents upgrade notification spam after git ops)
+.local_version
+
+# Worktree redirect file (contains relative path to main repo's .beads/)
+# Must not be committed as paths would be wrong in other clones
+redirect
+
+# Sync state (local-only, per-machine)
+# These files are machine-specific and should not be shared across clones
+.sync.lock
+export-state/
+export-state.json
+
+# Ephemeral store (SQLite - wisps/molecules, intentionally not versioned)
+ephemeral.sqlite3
+ephemeral.sqlite3-journal
+ephemeral.sqlite3-wal
+ephemeral.sqlite3-shm
+
+# Dolt server management (auto-started by bd)
+dolt-server.pid
+dolt-server.log
+dolt-server.lock
+dolt-server.port
+dolt-server.activity
+
+# Corrupt backup directories (created by bd doctor --fix recovery)
+*.corrupt.backup/
+
+# Backup data (auto-exported JSONL, local-only)
+backup/
+
+# Per-project environment file (Dolt connection config, GH#2520)
+.env
+
+# Legacy files (from pre-Dolt versions)
+*.db
+*.db?*
+*.db-journal
+*.db-wal
+*.db-shm
+db.sqlite
+bd.db
+# NOTE: Do NOT add negation patterns here.
+# They would override fork protection in .git/info/exclude.
+# Config files (metadata.json, config.yaml) are tracked by git by default
+# since no pattern above ignores them.

--- a/.beads/README.md
+++ b/.beads/README.md
@@ -1,0 +1,81 @@
+# Beads - AI-Native Issue Tracking
+
+Welcome to Beads! This repository uses **Beads** for issue tracking - a modern, AI-native tool designed to live directly in your codebase alongside your code.
+
+## What is Beads?
+
+Beads is issue tracking that lives in your repo, making it perfect for AI coding agents and developers who want their issues close to their code. No web UI required - everything works through the CLI and integrates seamlessly with git.
+
+**Learn more:** [github.com/steveyegge/beads](https://github.com/steveyegge/beads)
+
+## Quick Start
+
+### Essential Commands
+
+```bash
+# Create new issues
+bd create "Add user authentication"
+
+# View all issues
+bd list
+
+# View issue details
+bd show <issue-id>
+
+# Update issue status
+bd update <issue-id> --claim
+bd update <issue-id> --status done
+
+# Sync with Dolt remote
+bd dolt push
+```
+
+### Working with Issues
+
+Issues in Beads are:
+- **Git-native**: Stored in Dolt database with version control and branching
+- **AI-friendly**: CLI-first design works perfectly with AI coding agents
+- **Branch-aware**: Issues can follow your branch workflow
+- **Always in sync**: Auto-syncs with your commits
+
+## Why Beads?
+
+✨ **AI-Native Design**
+- Built specifically for AI-assisted development workflows
+- CLI-first interface works seamlessly with AI coding agents
+- No context switching to web UIs
+
+🚀 **Developer Focused**
+- Issues live in your repo, right next to your code
+- Works offline, syncs when you push
+- Fast, lightweight, and stays out of your way
+
+🔧 **Git Integration**
+- Automatic sync with git commits
+- Branch-aware issue tracking
+- Dolt-native three-way merge resolution
+
+## Get Started with Beads
+
+Try Beads in your own projects:
+
+```bash
+# Install Beads
+curl -sSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+
+# Initialize in your repo
+bd init
+
+# Create your first issue
+bd create "Try out Beads"
+```
+
+## Learn More
+
+- **Documentation**: [github.com/steveyegge/beads/docs](https://github.com/steveyegge/beads/tree/main/docs)
+- **Quick Start Guide**: Run `bd quickstart`
+- **Examples**: [github.com/steveyegge/beads/examples](https://github.com/steveyegge/beads/tree/main/examples)
+
+---
+
+*Beads: Issue tracking that moves at the speed of thought* ⚡

--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -1,0 +1,54 @@
+# Beads Configuration File
+# This file configures default behavior for all bd commands in this repository
+# All settings can also be set via environment variables (BD_* prefix)
+# or overridden with command-line flags
+
+# Issue prefix for this repository (used by bd init)
+# If not set, bd init will auto-detect from directory name
+# Example: issue-prefix: "myproject" creates issues like "myproject-1", "myproject-2", etc.
+# issue-prefix: ""
+
+# Use no-db mode: JSONL-only, no Dolt database
+# When true, bd will use .beads/issues.jsonl as the source of truth
+# no-db: false
+
+# Enable JSON output by default
+# json: false
+
+# Feedback title formatting for mutating commands (create/update/close/dep/edit)
+# 0 = hide titles, N > 0 = truncate to N characters
+# output:
+#   title-length: 255
+
+# Default actor for audit trails (overridden by BEADS_ACTOR or --actor)
+# actor: ""
+
+# Export events (audit trail) to .beads/events.jsonl on each flush/sync
+# When enabled, new events are appended incrementally using a high-water mark.
+# Use 'bd export --events' to trigger manually regardless of this setting.
+# events-export: false
+
+# Multi-repo configuration (experimental - bd-307)
+# Allows hydrating from multiple repositories and routing writes to the correct database
+# repos:
+#   primary: "."  # Primary repo (where this database lives)
+#   additional:   # Additional repos to hydrate from (read-only)
+#     - ~/beads-planning  # Personal planning repo
+#     - ~/work-planning   # Work planning repo
+
+# JSONL backup (periodic export for off-machine recovery)
+# Auto-enabled when a git remote exists. Override explicitly:
+# backup:
+#   enabled: false     # Disable auto-backup entirely
+#   interval: 15m      # Minimum time between auto-exports
+#   git-push: false    # Disable git push (export locally only)
+#   git-repo: ""       # Separate git repo for backups (default: project repo)
+
+# Integration settings (access with 'bd config get/set')
+# These are stored in the database, not in this file:
+# - jira.url
+# - jira.project
+# - linear.url
+# - linear.api-key
+# - github.org
+# - github.repo

--- a/.beads/hooks/post-checkout
+++ b/.beads/hooks/post-checkout
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v0.63.3 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run post-checkout "$@"
+    _bd_exit=$?
+    if [ $_bd_exit -eq 124 ]; then
+      echo >&2 "beads: hook 'post-checkout' timed out after ${_bd_timeout}s — continuing without beads"
+      _bd_exit=0
+    fi
+  else
+    bd hooks run post-checkout "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'post-checkout'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v0.63.3 ---

--- a/.beads/hooks/post-merge
+++ b/.beads/hooks/post-merge
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v0.63.3 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run post-merge "$@"
+    _bd_exit=$?
+    if [ $_bd_exit -eq 124 ]; then
+      echo >&2 "beads: hook 'post-merge' timed out after ${_bd_timeout}s — continuing without beads"
+      _bd_exit=0
+    fi
+  else
+    bd hooks run post-merge "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'post-merge'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v0.63.3 ---

--- a/.beads/hooks/pre-commit
+++ b/.beads/hooks/pre-commit
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v0.63.3 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run pre-commit "$@"
+    _bd_exit=$?
+    if [ $_bd_exit -eq 124 ]; then
+      echo >&2 "beads: hook 'pre-commit' timed out after ${_bd_timeout}s — continuing without beads"
+      _bd_exit=0
+    fi
+  else
+    bd hooks run pre-commit "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'pre-commit'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v0.63.3 ---

--- a/.beads/hooks/pre-push
+++ b/.beads/hooks/pre-push
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v0.63.3 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run pre-push "$@"
+    _bd_exit=$?
+    if [ $_bd_exit -eq 124 ]; then
+      echo >&2 "beads: hook 'pre-push' timed out after ${_bd_timeout}s — continuing without beads"
+      _bd_exit=0
+    fi
+  else
+    bd hooks run pre-push "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'pre-push'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v0.63.3 ---

--- a/.beads/hooks/prepare-commit-msg
+++ b/.beads/hooks/prepare-commit-msg
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# --- BEGIN BEADS INTEGRATION v0.63.3 ---
+# This section is managed by beads. Do not remove these markers.
+if command -v bd >/dev/null 2>&1; then
+  export BD_GIT_HOOK=1
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_bd_timeout" bd hooks run prepare-commit-msg "$@"
+    _bd_exit=$?
+    if [ $_bd_exit -eq 124 ]; then
+      echo >&2 "beads: hook 'prepare-commit-msg' timed out after ${_bd_timeout}s — continuing without beads"
+      _bd_exit=0
+    fi
+  else
+    bd hooks run prepare-commit-msg "$@"
+    _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 3 ]; then
+    echo >&2 "beads: database not initialized — skipping hook 'prepare-commit-msg'"
+    _bd_exit=0
+  fi
+  if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
+fi
+# --- END BEADS INTEGRATION v0.63.3 ---

--- a/.beads/metadata.json
+++ b/.beads/metadata.json
@@ -1,0 +1,7 @@
+{
+  "database": "dolt",
+  "backend": "dolt",
+  "dolt_mode": "embedded",
+  "dolt_database": "layercake_tool",
+  "project_id": "e6df9eb9-43df-486a-b25e-939aa3952979"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ frontend.log
 frontend/.env.development.local
 frontend/.env.local
 .env.local
+
+# Beads / Dolt files (added by bd init)
+.dolt/
+.beads-credential-key

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,3 +34,50 @@
 
 ## Removed Surfaces
 - The chat, RAG, and MCP surfaces have been removed from this workspace to keep Layercake focused on plan editing, graph tooling, data acquisition, and exports. Refer to `plans/20260122-de-feature.md` for the decision log and the remaining work history.
+
+<!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->
+## Beads Issue Tracker
+
+This project uses **bd (beads)** for issue tracking. Run `bd prime` to see full workflow context and commands.
+
+### Quick Reference
+
+```bash
+bd ready              # Find available work
+bd show <id>          # View issue details
+bd update <id> --claim  # Claim work
+bd close <id>         # Complete work
+```
+
+### Rules
+
+- Use `bd` for ALL task tracking — do NOT use TodoWrite, TaskCreate, or markdown TODO lists
+- Run `bd prime` for detailed command reference and session close protocol
+- Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
+
+## Session Completion
+
+**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
+
+**MANDATORY WORKFLOW:**
+
+1. **File issues for remaining work** - Create issues for anything that needs follow-up
+2. **Run quality gates** (if code changed) - Tests, linters, builds
+3. **Update issue status** - Close finished work, update in-progress items
+4. **PUSH TO REMOTE** - This is MANDATORY:
+   ```bash
+   git pull --rebase
+   bd dolt push
+   git push
+   git status  # MUST show "up to date with origin"
+   ```
+5. **Clean up** - Clear stashes, prune remote branches
+6. **Verify** - All changes committed AND pushed
+7. **Hand off** - Provide context for next session
+
+**CRITICAL RULES:**
+- Work is NOT complete until `git push` succeeds
+- NEVER stop before pushing - that leaves work stranded locally
+- NEVER say "ready to push when you are" - YOU must push
+- If push fails, resolve and retry until it succeeds
+<!-- END BEADS INTEGRATION -->

--- a/frontend/src/graphql/stories.ts
+++ b/frontend/src/graphql/stories.ts
@@ -10,6 +10,7 @@ export const LIST_STORIES = gql`
       description
       tags
       enabledDatasetIds
+      enabledGraphIds
       layerConfig {
         sourceDatasetId
         mode
@@ -31,6 +32,7 @@ export const GET_STORY = gql`
       description
       tags
       enabledDatasetIds
+      enabledGraphIds
       layerConfig {
         sourceDatasetId
         mode
@@ -52,6 +54,7 @@ export const CREATE_STORY = gql`
       description
       tags
       enabledDatasetIds
+      enabledGraphIds
       layerConfig {
         sourceDatasetId
         mode
@@ -73,6 +76,7 @@ export const UPDATE_STORY = gql`
       description
       tags
       enabledDatasetIds
+      enabledGraphIds
       layerConfig {
         sourceDatasetId
         mode
@@ -108,6 +112,7 @@ export interface Story {
   description: string | null
   tags: string[]
   enabledDatasetIds: number[]
+  enabledGraphIds: number[]
   layerConfig: StoryLayerConfig[]
   sequenceCount: number
   createdAt: string
@@ -120,6 +125,7 @@ export interface CreateStoryInput {
   description?: string
   tags?: string[]
   enabledDatasetIds?: number[]
+  enabledGraphIds?: number[]
   layerConfig?: StoryLayerConfig[]
 }
 
@@ -128,6 +134,7 @@ export interface UpdateStoryInput {
   description?: string
   tags?: string[]
   enabledDatasetIds?: number[]
+  enabledGraphIds?: number[]
   layerConfig?: StoryLayerConfig[]
 }
 

--- a/frontend/src/pages/StoryPage.tsx
+++ b/frontend/src/pages/StoryPage.tsx
@@ -22,6 +22,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Spinner } from '@/components/ui/spinner'
 import { GET_STORY, UPDATE_STORY, Story, StoryLayerConfig, UpdateStoryInput } from '@/graphql/stories'
 import { GET_DATASOURCES, DataSet } from '@/graphql/datasets'
+import { GET_GRAPHS } from '@/graphql/graphs'
 import { StorySequencesEditor } from '@/components/stories/StorySequencesEditor'
 import { StoryLayersTab } from '@/components/stories/StoryLayersTab'
 
@@ -60,6 +61,7 @@ export const StoryPage = () => {
   const [description, setDescription] = useState('')
   const [tagsInput, setTagsInput] = useState('')
   const [enabledDatasetIds, setEnabledDatasetIds] = useState<number[]>([])
+  const [enabledGraphIds, setEnabledGraphIds] = useState<number[]>([])
   const [layerConfig, setLayerConfig] = useState<StoryLayerConfig[]>([])
   const [hasChanges, setHasChanges] = useState(false)
 
@@ -78,6 +80,14 @@ export const StoryPage = () => {
     skip: !projectIdNum,
   })
   const allDatasets: DataSet[] = (datasetsData as any)?.dataSets || []
+
+  const { data: graphsData } = useQuery(GET_GRAPHS, {
+    variables: { projectId: projectIdNum },
+    skip: !projectIdNum,
+  })
+  // Computed graphs (a GraphNode's output) the story can also source edges from.
+  const graphs: Array<{ id: number; name: string; nodeCount?: number; edgeCount?: number }> =
+    ((graphsData as any)?.graphs || []).filter((g: any) => (g.edgeCount || 0) > 0)
 
   // Filter to only show datasets with edge data
   const datasets = allDatasets.filter((ds) => {
@@ -107,6 +117,7 @@ export const StoryPage = () => {
       setDescription(story.description || '')
       setTagsInput(story.tags.join(', '))
       setEnabledDatasetIds(story.enabledDatasetIds)
+      setEnabledGraphIds(story.enabledGraphIds || [])
       setLayerConfig(story.layerConfig || [])
       setHasChanges(false)
     }
@@ -129,6 +140,7 @@ export const StoryPage = () => {
       description: description || undefined,
       tags,
       enabledDatasetIds,
+      enabledGraphIds,
       layerConfig: cleanLayerConfig,
     }
 
@@ -150,6 +162,13 @@ export const StoryPage = () => {
       prev.includes(datasetId)
         ? prev.filter((id) => id !== datasetId)
         : [...prev, datasetId]
+    )
+    setHasChanges(true)
+  }
+
+  const toggleGraph = (graphId: number) => {
+    setEnabledGraphIds((prev) =>
+      prev.includes(graphId) ? prev.filter((id) => id !== graphId) : [...prev, graphId]
     )
     setHasChanges(true)
   }
@@ -341,6 +360,36 @@ export const StoryPage = () => {
                     </div>
                   ))}
                 </Stack>
+              )}
+
+              {graphs.length > 0 && (
+                <>
+                  <p className="text-sm font-medium mt-6 mb-1">Computed graphs</p>
+                  <p className="text-xs text-muted-foreground mb-3">
+                    A story can also source edges from a computed graph (a GraphNode's
+                    merged/transformed output), not just raw datasets.
+                  </p>
+                  <Stack gap="sm">
+                    {graphs.map((graph) => (
+                      <div key={graph.id} className="flex items-center space-x-3">
+                        <Checkbox
+                          id={`graph-${graph.id}`}
+                          checked={enabledGraphIds.includes(graph.id)}
+                          onCheckedChange={() => toggleGraph(graph.id)}
+                        />
+                        <label
+                          htmlFor={`graph-${graph.id}`}
+                          className="flex-1 text-sm cursor-pointer"
+                        >
+                          <div className="font-medium">{graph.name}</div>
+                          <div className="text-xs text-muted-foreground">
+                            {graph.nodeCount || 0} nodes, {graph.edgeCount || 0} edges (computed)
+                          </div>
+                        </label>
+                      </div>
+                    ))}
+                  </Stack>
+                </>
               )}
             </CardContent>
           </Card>

--- a/layercake-core/src/app_context/graph_operations.rs
+++ b/layercake-core/src/app_context/graph_operations.rs
@@ -434,6 +434,39 @@ impl AppContext {
             .map_err(|e| CoreError::internal("Failed to update graph data").with_source(e))
     }
 
+    /// Diff two datasets by their graph_json. Both must belong to the same
+    /// project (read access is authorized on it). Answers "what changed" —
+    /// added/removed/changed nodes and edges.
+    pub async fn diff_datasets(
+        &self,
+        actor: &Actor,
+        from_dataset_id: i32,
+        to_dataset_id: i32,
+    ) -> CoreResult<crate::graph_diff::GraphDiff> {
+        use crate::database::entities::data_sets;
+        use sea_orm::EntityTrait;
+
+        let load = |id: i32| async move {
+            data_sets::Entity::find_by_id(id)
+                .one(&self.db)
+                .await
+                .map_err(|e| CoreError::internal("Failed to load dataset").with_source(e))?
+                .ok_or_else(|| CoreError::not_found("DataSet", id.to_string()))
+        };
+        let from = load(from_dataset_id).await?;
+        let to = load(to_dataset_id).await?;
+
+        if from.project_id != to.project_id {
+            return Err(CoreError::validation(
+                "the two datasets belong to different projects",
+            ));
+        }
+        self.authorize_project_read(actor, from.project_id).await?;
+
+        crate::graph_diff::diff_graph_json(&from.graph_json, &to.graph_json)
+            .map_err(|e| CoreError::internal(format!("Failed to diff dataset graphs: {}", e)))
+    }
+
     /// Delete computed graphs whose originating DAG node no longer exists.
     /// Returns the pruned graph ids.
     pub async fn prune_orphaned_graphs(

--- a/layercake-core/src/app_context/plan_dag_operations.rs
+++ b/layercake-core/src/app_context/plan_dag_operations.rs
@@ -291,6 +291,20 @@ impl AppContext {
             .await
     }
 
+    pub async fn rename_plan_dag_node(
+        &self,
+        actor: &Actor,
+        project_id: i32,
+        plan_id: Option<i32>,
+        old_id: String,
+        new_id: String,
+    ) -> CoreResult<PlanDagNode> {
+        self.authorize_project_write(actor, project_id).await?;
+        self.plan_dag_service
+            .rename_node(project_id, plan_id, old_id, new_id)
+            .await
+    }
+
     pub async fn delete_plan_dag_node(
         &self,
         actor: &Actor,

--- a/layercake-core/src/graph_diff.rs
+++ b/layercake-core/src/graph_diff.rs
@@ -1,0 +1,137 @@
+//! Structural diff between two graphs (datasets or computed graphs).
+//!
+//! Answers "what did the merge/transform do?" — the added/removed/changed nodes
+//! and edges between a `from` and a `to` graph, keyed by id. Change detection
+//! compares the full serialised item, so any field difference (label, layer,
+//! weight, attrs…) counts as a change.
+
+use crate::graph::{Edge, Graph, Node};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct GraphDiff {
+    pub nodes: ItemDiff,
+    pub edges: ItemDiff,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ItemDiff {
+    /// Ids present in `to` but not `from`.
+    pub added: Vec<String>,
+    /// Ids present in `from` but not `to`.
+    pub removed: Vec<String>,
+    /// Ids present in both but with differing content.
+    pub changed: Vec<String>,
+    /// Count present in both and identical.
+    pub unchanged: usize,
+}
+
+impl GraphDiff {
+    pub fn is_empty(&self) -> bool {
+        self.nodes.added.is_empty()
+            && self.nodes.removed.is_empty()
+            && self.nodes.changed.is_empty()
+            && self.edges.added.is_empty()
+            && self.edges.removed.is_empty()
+            && self.edges.changed.is_empty()
+    }
+}
+
+/// Diff two graphs parsed from their JSON representations.
+pub fn diff_graph_json(from_json: &str, to_json: &str) -> Result<GraphDiff, serde_json::Error> {
+    let from: Graph = serde_json::from_str(from_json)?;
+    let to: Graph = serde_json::from_str(to_json)?;
+    Ok(diff_graphs(&from, &to))
+}
+
+pub fn diff_graphs(from: &Graph, to: &Graph) -> GraphDiff {
+    GraphDiff {
+        nodes: diff_items(&from.nodes, &to.nodes, node_id),
+        edges: diff_items(&from.edges, &to.edges, edge_id),
+    }
+}
+
+fn node_id(n: &Node) -> String {
+    n.id.clone()
+}
+
+fn edge_id(e: &Edge) -> String {
+    if e.id.is_empty() {
+        format!("{}:{}", e.source, e.target)
+    } else {
+        e.id.clone()
+    }
+}
+
+fn diff_items<T: Serialize, F: Fn(&T) -> String>(from: &[T], to: &[T], id_of: F) -> ItemDiff {
+    let from_map: HashMap<String, serde_json::Value> = from
+        .iter()
+        .map(|item| (id_of(item), serde_json::to_value(item).unwrap_or_default()))
+        .collect();
+    let to_map: HashMap<String, serde_json::Value> = to
+        .iter()
+        .map(|item| (id_of(item), serde_json::to_value(item).unwrap_or_default()))
+        .collect();
+
+    let mut diff = ItemDiff::default();
+    for (id, to_val) in &to_map {
+        match from_map.get(id) {
+            None => diff.added.push(id.clone()),
+            Some(from_val) if from_val != to_val => diff.changed.push(id.clone()),
+            Some(_) => diff.unchanged += 1,
+        }
+    }
+    for id in from_map.keys() {
+        if !to_map.contains_key(id) {
+            diff.removed.push(id.clone());
+        }
+    }
+    diff.added.sort();
+    diff.removed.sort();
+    diff.changed.sort();
+    diff
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn g(json: &str) -> String {
+        json.to_string()
+    }
+
+    #[test]
+    fn detects_added_removed_changed() {
+        let from = g(r#"{"nodes":[
+            {"id":"a","label":"A","layer":"l","weight":1},
+            {"id":"b","label":"B","layer":"l","weight":1}
+        ],"edges":[
+            {"id":"e1","source":"a","target":"b","label":"x","layer":"l","weight":1}
+        ],"layers":[]}"#);
+        let to = g(r#"{"nodes":[
+            {"id":"a","label":"A2","layer":"l","weight":1},
+            {"id":"c","label":"C","layer":"l","weight":1}
+        ],"edges":[
+            {"id":"e1","source":"a","target":"b","label":"x","layer":"l","weight":1}
+        ],"layers":[]}"#);
+
+        let d = diff_graph_json(&from, &to).unwrap();
+        assert_eq!(d.nodes.added, vec!["c"]);       // c is new
+        assert_eq!(d.nodes.removed, vec!["b"]);     // b is gone
+        assert_eq!(d.nodes.changed, vec!["a"]);     // a's label changed
+        assert_eq!(d.edges.unchanged, 1);           // e1 identical
+        assert!(d.edges.added.is_empty() && d.edges.removed.is_empty());
+        assert!(!d.is_empty());
+    }
+
+    #[test]
+    fn identical_graphs_diff_empty() {
+        let j = g(r#"{"nodes":[{"id":"a","label":"A","layer":"l","weight":1}],"edges":[],"layers":[]}"#);
+        let d = diff_graph_json(&j, &j).unwrap();
+        assert!(d.is_empty());
+        assert_eq!(d.nodes.unchanged, 1);
+    }
+}

--- a/layercake-core/src/lib.rs
+++ b/layercake-core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod plan_dag;
 pub mod plan_execution;
 pub mod doctor;
 pub mod graph_diff;
+pub mod palette;
 pub mod sequence_context;
 pub mod sequence_types;
 pub mod story_types;

--- a/layercake-core/src/lib.rs
+++ b/layercake-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod plan;
 pub mod plan_dag;
 pub mod plan_execution;
 pub mod doctor;
+pub mod graph_diff;
 pub mod sequence_context;
 pub mod sequence_types;
 pub mod story_types;

--- a/layercake-core/src/palette.rs
+++ b/layercake-core/src/palette.rs
@@ -1,0 +1,163 @@
+//! Layer colour palettes + WCAG contrast checking.
+//!
+//! Provides curated, accessibility-validated palettes agents can apply to
+//! project layers, and a WCAG contrast calculator so a background/text pair can
+//! be checked before it's used (a near-white-on-white palette "disappears" —
+//! this catches that).
+
+use serde::{Deserialize, Serialize};
+
+/// One layer's colours.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PaletteSwatch {
+    pub name: String,
+    pub background_color: String,
+    pub text_color: String,
+    pub border_color: String,
+    /// WCAG contrast ratio of text on background (1.0–21.0).
+    pub contrast_ratio: f64,
+    /// Passes WCAG AA for normal text (>= 4.5).
+    pub passes_aa: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Palette {
+    pub name: String,
+    pub description: String,
+    pub swatches: Vec<PaletteSwatch>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ContrastResult {
+    pub ratio: f64,
+    pub passes_aa: bool,       // >= 4.5 (normal text)
+    pub passes_aa_large: bool, // >= 3.0 (large text / UI)
+    pub passes_aaa: bool,      // >= 7.0
+}
+
+/// Parse `#rrggbb` (or `rrggbb`) to (r,g,b) in 0..=255.
+fn parse_hex(color: &str) -> Option<(u8, u8, u8)> {
+    let h = color.trim().trim_start_matches('#');
+    if h.len() != 6 {
+        return None;
+    }
+    let r = u8::from_str_radix(&h[0..2], 16).ok()?;
+    let g = u8::from_str_radix(&h[2..4], 16).ok()?;
+    let b = u8::from_str_radix(&h[4..6], 16).ok()?;
+    Some((r, g, b))
+}
+
+fn channel_luminance(c: u8) -> f64 {
+    let s = c as f64 / 255.0;
+    if s <= 0.03928 {
+        s / 12.92
+    } else {
+        ((s + 0.055) / 1.055).powf(2.4)
+    }
+}
+
+/// WCAG relative luminance of an sRGB colour.
+fn relative_luminance((r, g, b): (u8, u8, u8)) -> f64 {
+    0.2126 * channel_luminance(r) + 0.7152 * channel_luminance(g) + 0.0722 * channel_luminance(b)
+}
+
+/// WCAG contrast ratio between two colours (1.0–21.0). Returns None if either
+/// colour can't be parsed.
+pub fn contrast_ratio(a: &str, b: &str) -> Option<f64> {
+    let la = relative_luminance(parse_hex(a)?);
+    let lb = relative_luminance(parse_hex(b)?);
+    let (hi, lo) = if la >= lb { (la, lb) } else { (lb, la) };
+    Some((hi + 0.05) / (lo + 0.05))
+}
+
+/// Full WCAG check for a background/text pair.
+pub fn check_contrast(background: &str, text: &str) -> Option<ContrastResult> {
+    let ratio = contrast_ratio(background, text)?;
+    Some(ContrastResult {
+        ratio: (ratio * 100.0).round() / 100.0,
+        passes_aa: ratio >= 4.5,
+        passes_aa_large: ratio >= 3.0,
+        passes_aaa: ratio >= 7.0,
+    })
+}
+
+fn swatch(name: &str, bg: &str, text: &str, border: &str) -> PaletteSwatch {
+    let ratio = contrast_ratio(bg, text).unwrap_or(1.0);
+    PaletteSwatch {
+        name: name.into(),
+        background_color: bg.into(),
+        text_color: text.into(),
+        border_color: border.into(),
+        contrast_ratio: (ratio * 100.0).round() / 100.0,
+        passes_aa: ratio >= 4.5,
+    }
+}
+
+/// Curated palettes. All swatches are AA-compliant (text on background).
+pub fn presets() -> Vec<Palette> {
+    vec![
+        Palette {
+            name: "slate".into(),
+            description: "Neutral slate tones, AA-compliant, distinct from a white UI".into(),
+            swatches: vec![
+                swatch("primary", "#1f2937", "#f9fafb", "#111827"),
+                swatch("secondary", "#334155", "#f8fafc", "#1e293b"),
+                swatch("accent", "#0e7490", "#ecfeff", "#155e75"),
+                swatch("muted", "#475569", "#f1f5f9", "#334155"),
+            ],
+        },
+        Palette {
+            name: "warm".into(),
+            description: "Warm earth tones, AA-compliant".into(),
+            swatches: vec![
+                swatch("primary", "#7c2d12", "#fff7ed", "#431407"),
+                swatch("secondary", "#9a3412", "#fff7ed", "#7c2d12"),
+                swatch("accent", "#a16207", "#fefce8", "#854d0e"),
+                swatch("muted", "#78350f", "#fffbeb", "#451a03"),
+            ],
+        },
+        Palette {
+            name: "cool".into(),
+            description: "Cool blues/greens, AA-compliant".into(),
+            swatches: vec![
+                swatch("primary", "#1e3a8a", "#eff6ff", "#1e40af"),
+                swatch("secondary", "#065f46", "#ecfdf5", "#064e3b"),
+                swatch("accent", "#5b21b6", "#f5f3ff", "#4c1d95"),
+                swatch("muted", "#334155", "#f8fafc", "#1e293b"),
+            ],
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn contrast_ratio_extremes() {
+        // Black on white is the maximum, ~21:1.
+        let r = contrast_ratio("#000000", "#ffffff").unwrap();
+        assert!((r - 21.0).abs() < 0.1, "{r}");
+        // Same colour is 1:1.
+        assert!((contrast_ratio("#777777", "#777777").unwrap() - 1.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn near_white_on_white_fails_aa() {
+        // The kind of "disappears next to a white UI" pair the reviewer flagged.
+        let c = check_contrast("#f7f7f8", "#ffffff").unwrap();
+        assert!(!c.passes_aa, "near-white-on-white should fail AA: {:?}", c);
+    }
+
+    #[test]
+    fn all_presets_pass_aa() {
+        for p in presets() {
+            for s in p.swatches {
+                assert!(s.passes_aa, "{} / {} fails AA ({})", p.name, s.name, s.contrast_ratio);
+            }
+        }
+    }
+}

--- a/layercake-core/src/pipeline/dag_executor.rs
+++ b/layercake-core/src/pipeline/dag_executor.rs
@@ -28,6 +28,16 @@ pub struct DagExecutor {
     /// Non-fatal warnings accumulated during a run, surfaced on the execution
     /// result so callers see them without reading logs or context_json.
     warnings: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+    /// Per-node execution records (id, type, duration) accumulated during a run.
+    node_records: std::sync::Arc<std::sync::Mutex<Vec<NodeExecutionRecord>>>,
+}
+
+/// Timing/outcome for a single node executed during a DAG run.
+#[derive(Debug, Clone)]
+pub struct NodeExecutionRecord {
+    pub node_id: String,
+    pub node_type: String,
+    pub duration_ms: u64,
 }
 
 /// Options for creating or updating graph_data records originating from DAG nodes
@@ -68,6 +78,7 @@ impl DagExecutor {
             graph_data_builder,
             merge_builder,
             warnings: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
+            node_records: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
         }
     }
 
@@ -77,11 +88,25 @@ impl DagExecutor {
         }
     }
 
+    fn push_node_record(&self, record: NodeExecutionRecord) {
+        if let Ok(mut r) = self.node_records.lock() {
+            r.push(record);
+        }
+    }
+
     /// Take the warnings accumulated so far, clearing the buffer.
     pub fn take_warnings(&self) -> Vec<String> {
         self.warnings
             .lock()
             .map(|mut w| std::mem::take(&mut *w))
+            .unwrap_or_default()
+    }
+
+    /// Take the per-node execution records accumulated so far, clearing them.
+    pub fn take_node_records(&self) -> Vec<NodeExecutionRecord> {
+        self.node_records
+            .lock()
+            .map(|mut r| std::mem::take(&mut *r))
             .unwrap_or_default()
     }
 
@@ -1335,6 +1360,7 @@ impl DagExecutor {
                 plan_id,
                 node_id = node_id.as_str()
             );
+            let started = std::time::Instant::now();
             self.execute_node(
                 project_id,
                 plan_id,
@@ -1345,6 +1371,16 @@ impl DagExecutor {
             )
             .instrument(span)
             .await?;
+            let node_type = nodes
+                .iter()
+                .find(|n| n.id == node_id)
+                .map(|n| n.node_type.clone())
+                .unwrap_or_default();
+            self.push_node_record(NodeExecutionRecord {
+                node_id: node_id.clone(),
+                node_type,
+                duration_ms: started.elapsed().as_millis() as u64,
+            });
         }
 
         Ok(())

--- a/layercake-core/src/pipeline/mod.rs
+++ b/layercake-core/src/pipeline/mod.rs
@@ -8,7 +8,7 @@ mod merge_builder;
 #[allow(dead_code)]
 mod types;
 
-pub use dag_executor::DagExecutor;
+pub use dag_executor::{DagExecutor, NodeExecutionRecord};
 pub use dataset_importer::DatasourceImporter;
 pub use graph_data_builder::GraphDataBuilder;
 pub use merge_builder::MergeBuilder;

--- a/layercake-core/src/services/plan_dag_service.rs
+++ b/layercake-core/src/services/plan_dag_service.rs
@@ -351,6 +351,108 @@ impl PlanDagService {
         Ok(result_node)
     }
 
+    /// Rename a Plan DAG node to a new (human-readable) id, rewriting every
+    /// reference to it: connected edges' source/target and any computed graph's
+    /// `dag_node_id`. Fails if `new_id` already exists in the plan.
+    pub async fn rename_node(
+        &self,
+        project_id: i32,
+        plan_id: Option<i32>,
+        old_id: String,
+        new_id: String,
+    ) -> CoreResult<PlanDagNode> {
+        use sea_orm::{ConnectionTrait, Statement, TransactionTrait};
+
+        if new_id.trim().is_empty() {
+            return Err(CoreError::validation("new node id cannot be empty"));
+        }
+        if new_id == old_id {
+            // No-op rename; return the current node.
+            let node = plan_dag_nodes::Entity::find()
+                .filter(plan_dag_nodes::Column::Id.eq(&new_id))
+                .one(&self.db)
+                .await
+                .map_err(|e| CoreError::internal(format!("Database error: {}", e)))?
+                .ok_or_else(|| CoreError::not_found("PlanDagNode", old_id))?;
+            return Ok(PlanDagNode::from(node));
+        }
+
+        let plan = self.resolve_plan(project_id, plan_id).await?;
+        let backend = self.db.get_database_backend();
+
+        // Old node must exist; new id must be free (within the plan).
+        let exists = |id: &str| {
+            plan_dag_nodes::Entity::find().filter(
+                plan_dag_nodes::Column::PlanId
+                    .eq(plan.id)
+                    .and(plan_dag_nodes::Column::Id.eq(id.to_string())),
+            )
+        };
+        if exists(&old_id)
+            .one(&self.db)
+            .await
+            .map_err(|e| CoreError::internal(format!("Database error: {}", e)))?
+            .is_none()
+        {
+            return Err(CoreError::not_found("PlanDagNode", old_id));
+        }
+        if exists(&new_id)
+            .one(&self.db)
+            .await
+            .map_err(|e| CoreError::internal(format!("Database error: {}", e)))?
+            .is_some()
+        {
+            return Err(CoreError::validation(format!(
+                "a node with id '{}' already exists in this plan",
+                new_id
+            )));
+        }
+
+        let txn = self
+            .db
+            .begin()
+            .await
+            .map_err(|e| CoreError::internal(format!("Failed to begin rename txn: {}", e)))?;
+
+        let stmts = [
+            (
+                "UPDATE plan_dag_nodes SET id = ? WHERE plan_id = ? AND id = ?",
+                vec![new_id.clone().into(), plan.id.into(), old_id.clone().into()],
+            ),
+            (
+                "UPDATE plan_dag_edges SET source_node_id = ? WHERE plan_id = ? AND source_node_id = ?",
+                vec![new_id.clone().into(), plan.id.into(), old_id.clone().into()],
+            ),
+            (
+                "UPDATE plan_dag_edges SET target_node_id = ? WHERE plan_id = ? AND target_node_id = ?",
+                vec![new_id.clone().into(), plan.id.into(), old_id.clone().into()],
+            ),
+            (
+                "UPDATE graph_data SET dag_node_id = ? WHERE project_id = ? AND dag_node_id = ?",
+                vec![new_id.clone().into(), project_id.into(), old_id.clone().into()],
+            ),
+        ];
+        for (sql, params) in stmts {
+            txn.execute(Statement::from_sql_and_values(backend, sql, params))
+                .await
+                .map_err(|e| CoreError::internal(format!("Rename failed: {}", e)))?;
+        }
+
+        txn.commit()
+            .await
+            .map_err(|e| CoreError::internal(format!("Failed to commit rename: {}", e)))?;
+
+        let _ = self.bump_plan_version(plan.id).await;
+
+        let renamed = plan_dag_nodes::Entity::find()
+            .filter(plan_dag_nodes::Column::Id.eq(&new_id))
+            .one(&self.db)
+            .await
+            .map_err(|e| CoreError::internal(format!("Database error: {}", e)))?
+            .ok_or_else(|| CoreError::not_found("PlanDagNode", new_id))?;
+        Ok(PlanDagNode::from(renamed))
+    }
+
     /// Delete a Plan DAG node and its connected edges
     pub async fn delete_node(
         &self,
@@ -1413,15 +1515,114 @@ impl PlanDagService {
 
 #[cfg(test)]
 mod tests {
-    #[allow(unused_imports)]
     use super::*;
+    use crate::database::entities::{plan_dag_edges, plan_dag_nodes, plans, projects};
+    use crate::database::test_utils::setup_test_db;
+    use sea_orm::Set;
 
-    // Note: These would be integration tests requiring a test database
-    // For now, just testing the service creation
+    async fn seed(db: &DatabaseConnection) {
+        projects::ActiveModel {
+            id: Set(1),
+            name: Set("P".into()),
+            description: Set(None),
+            tags: Set("[]".into()),
+            import_export_path: Set(None),
+            created_at: Set(Utc::now().into()),
+            updated_at: Set(Utc::now().into()),
+        }
+        .insert(db)
+        .await
+        .unwrap();
+        plans::ActiveModel {
+            id: Set(1),
+            project_id: Set(1),
+            name: Set("plan".into()),
+            description: Set(None),
+            tags: Set("[]".into()),
+            yaml_content: Set("".into()),
+            dependencies: Set(None),
+            status: Set("active".into()),
+            version: Set(1),
+            created_at: Set(Utc::now().into()),
+            updated_at: Set(Utc::now().into()),
+        }
+        .insert(db)
+        .await
+        .unwrap();
+        for (id, ty) in [("a", "DataSetNode"), ("b", "GraphNode")] {
+            plan_dag_nodes::ActiveModel {
+                id: Set(id.into()),
+                plan_id: Set(1),
+                node_type: Set(ty.into()),
+                position_x: Set(0.0),
+                position_y: Set(0.0),
+                source_position: Set(None),
+                target_position: Set(None),
+                metadata_json: Set("{}".into()),
+                config_json: Set("{}".into()),
+                created_at: Set(Utc::now().into()),
+                updated_at: Set(Utc::now().into()),
+            }
+            .insert(db)
+            .await
+            .unwrap();
+        }
+        plan_dag_edges::ActiveModel {
+            id: Set("e1".into()),
+            plan_id: Set(1),
+            source_node_id: Set("a".into()),
+            target_node_id: Set("b".into()),
+            metadata_json: Set("{}".into()),
+            created_at: Set(Utc::now().into()),
+            updated_at: Set(Utc::now().into()),
+        }
+        .insert(db)
+        .await
+        .unwrap();
+    }
 
-    #[test]
-    fn test_service_creation() {
-        // This would require a real database connection for proper testing
-        // We'll add integration tests when we have a test database setup
+    #[tokio::test]
+    async fn rename_updates_node_and_edges() {
+        let db = setup_test_db().await;
+        seed(&db).await;
+        let svc = PlanDagService::new(db.clone());
+
+        svc.rename_node(1, Some(1), "a".into(), "source_data".into())
+            .await
+            .unwrap();
+
+        // Node renamed.
+        assert!(plan_dag_nodes::Entity::find()
+            .filter(plan_dag_nodes::Column::Id.eq("source_data"))
+            .one(&db)
+            .await
+            .unwrap()
+            .is_some());
+        assert!(plan_dag_nodes::Entity::find()
+            .filter(plan_dag_nodes::Column::Id.eq("a"))
+            .one(&db)
+            .await
+            .unwrap()
+            .is_none());
+        // Edge source followed.
+        let edge = plan_dag_edges::Entity::find_by_id("e1")
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(edge.source_node_id, "source_data");
+        assert_eq!(edge.target_node_id, "b");
+    }
+
+    #[tokio::test]
+    async fn rename_to_existing_id_is_rejected() {
+        let db = setup_test_db().await;
+        seed(&db).await;
+        let svc = PlanDagService::new(db.clone());
+        let err = svc
+            .rename_node(1, Some(1), "a".into(), "b".into())
+            .await
+            .unwrap_err();
+        assert!(format!("{err}").contains("already exists"), "{err}");
     }
 }

--- a/layercake-server/src/graphql/mutations/helpers.rs
+++ b/layercake-server/src/graphql/mutations/helpers.rs
@@ -510,6 +510,26 @@ pub struct PlanExecutionResult {
     /// Non-fatal problems encountered during execution (e.g. a story sequence
     /// that resolved no steps). Empty on a fully clean run.
     pub warnings: Vec<String>,
+    /// Per-node execution timings, in topological order.
+    pub node_results: Vec<NodeExecutionTiming>,
+}
+
+/// Timing for a single node in a plan execution.
+#[derive(async_graphql::SimpleObject)]
+pub struct NodeExecutionTiming {
+    pub node_id: String,
+    pub node_type: String,
+    pub duration_ms: i64,
+}
+
+impl From<layercake_core::pipeline::NodeExecutionRecord> for NodeExecutionTiming {
+    fn from(r: layercake_core::pipeline::NodeExecutionRecord) -> Self {
+        Self {
+            node_id: r.node_id,
+            node_type: r.node_type,
+            duration_ms: r.duration_ms as i64,
+        }
+    }
 }
 
 #[derive(async_graphql::SimpleObject)]

--- a/layercake-server/src/graphql/mutations/plan.rs
+++ b/layercake-server/src/graphql/mutations/plan.rs
@@ -141,6 +141,7 @@ impl PlanMutation {
                 message: "No nodes to execute in this plan".to_string(),
                 output_files: vec![],
                 warnings: vec![],
+                node_results: vec![],
             });
         }
 
@@ -166,11 +167,17 @@ impl PlanMutation {
             .map_err(|e| StructuredError::service("DagExecutor::execute_dag", e))?;
 
         let warnings = executor.take_warnings();
+        let node_results = executor
+            .take_node_records()
+            .into_iter()
+            .map(super::helpers::NodeExecutionTiming::from)
+            .collect();
         Ok(PlanExecutionResult {
             success: true,
             message: format!("Executed {} nodes in topological order", nodes.len()),
             output_files: vec![],
             warnings,
+            node_results,
         })
     }
 

--- a/layercake-server/src/graphql/mutations/plan_dag_nodes.rs
+++ b/layercake-server/src/graphql/mutations/plan_dag_nodes.rs
@@ -111,6 +111,28 @@ impl PlanDagNodesMutation {
         Ok(Some(PlanDagNode::from(updated)))
     }
 
+    /// Rename a Plan DAG node to a new (human-readable) id. Rewrites every
+    /// reference: connected edges and any computed graph's origin. Fails if the
+    /// new id already exists in the plan.
+    #[graphql(name = "renamePlanDagNode")]
+    async fn rename_plan_dag_node(
+        &self,
+        ctx: &Context<'_>,
+        project_id: i32,
+        plan_id: Option<i32>,
+        #[graphql(name = "oldId")] old_id: String,
+        #[graphql(name = "newId")] new_id: String,
+    ) -> Result<Option<PlanDagNode>> {
+        let context = ctx.data::<GraphQLContext>()?;
+        let actor = context.actor_for_request(ctx).await;
+        let renamed = context
+            .app
+            .rename_plan_dag_node(&actor, project_id, plan_id, old_id, new_id)
+            .await
+            .map_err(crate::graphql::errors::core_error_to_graphql_error)?;
+        Ok(Some(PlanDagNode::from(renamed)))
+    }
+
     /// Delete a Plan DAG node
     async fn delete_plan_dag_node(
         &self,

--- a/layercake-server/src/graphql/queries/mod.rs
+++ b/layercake-server/src/graphql/queries/mod.rs
@@ -92,6 +92,25 @@ impl Query {
         Ok(GraphSummary::from(summary))
     }
 
+    /// Structural diff between two datasets' graphs — added/removed/changed
+    /// nodes and edges. Answers "what did the merge/transform do?".
+    #[graphql(name = "diffDatasets")]
+    async fn diff_datasets(
+        &self,
+        ctx: &Context<'_>,
+        #[graphql(name = "fromDatasetId")] from_dataset_id: i32,
+        #[graphql(name = "toDatasetId")] to_dataset_id: i32,
+    ) -> Result<crate::graphql::types::graph_diff::GraphDiff> {
+        let context = ctx.data::<GraphQLContext>()?;
+        let actor = context.actor_for_request(ctx).await;
+        let diff = context
+            .app
+            .diff_datasets(&actor, from_dataset_id, to_dataset_id)
+            .await
+            .map_err(crate::graphql::errors::core_error_to_graphql_error)?;
+        Ok(diff.into())
+    }
+
     async fn graph_page(
         &self,
         ctx: &Context<'_>,

--- a/layercake-server/src/graphql/queries/mod.rs
+++ b/layercake-server/src/graphql/queries/mod.rs
@@ -201,6 +201,32 @@ impl Query {
         Ok(sequence.map(Sequence::from))
     }
 
+    /// Curated, WCAG-AA-validated colour palettes to apply to project layers.
+    #[graphql(name = "palettePresets")]
+    async fn palette_presets(&self) -> Vec<crate::graphql::types::palette::Palette> {
+        layercake_core::palette::presets()
+            .into_iter()
+            .map(Into::into)
+            .collect()
+    }
+
+    /// WCAG contrast check for a background/text colour pair (hex).
+    #[graphql(name = "checkContrast")]
+    async fn check_contrast(
+        &self,
+        background: String,
+        text: String,
+    ) -> Result<crate::graphql::types::palette::ContrastResult> {
+        layercake_core::palette::check_contrast(&background, &text)
+            .map(Into::into)
+            .ok_or_else(|| {
+                crate::graphql::errors::StructuredError::validation(
+                    "colors",
+                    "background and text must be hex colours like #rrggbb",
+                )
+            })
+    }
+
     /// Build a story's sequence render context and return it as a JSON string,
     /// without going through the Handlebars template. Lets a client render the
     /// diagram itself, or inspect participants/steps/warnings directly.

--- a/layercake-server/src/graphql/types/graph_diff.rs
+++ b/layercake-server/src/graphql/types/graph_diff.rs
@@ -1,0 +1,41 @@
+use async_graphql::SimpleObject;
+
+/// Structural diff between two graphs (datasets or computed graphs).
+#[derive(SimpleObject)]
+pub struct GraphDiff {
+    pub nodes: ItemDiff,
+    pub edges: ItemDiff,
+}
+
+/// Added/removed/changed ids for one item kind (nodes or edges).
+#[derive(SimpleObject)]
+pub struct ItemDiff {
+    /// Ids present in `to` but not `from`.
+    pub added: Vec<String>,
+    /// Ids present in `from` but not `to`.
+    pub removed: Vec<String>,
+    /// Ids present in both but with differing content.
+    pub changed: Vec<String>,
+    /// Count present in both and identical.
+    pub unchanged: i32,
+}
+
+impl From<layercake_core::graph_diff::ItemDiff> for ItemDiff {
+    fn from(d: layercake_core::graph_diff::ItemDiff) -> Self {
+        Self {
+            added: d.added,
+            removed: d.removed,
+            changed: d.changed,
+            unchanged: d.unchanged as i32,
+        }
+    }
+}
+
+impl From<layercake_core::graph_diff::GraphDiff> for GraphDiff {
+    fn from(d: layercake_core::graph_diff::GraphDiff) -> Self {
+        Self {
+            nodes: d.nodes.into(),
+            edges: d.edges.into(),
+        }
+    }
+}

--- a/layercake-server/src/graphql/types/mod.rs
+++ b/layercake-server/src/graphql/types/mod.rs
@@ -8,6 +8,7 @@ pub mod story;
 pub mod data_set;
 pub mod graph;
 pub mod graph_data;
+pub mod graph_diff;
 pub mod graph_edge;
 pub mod graph_edit;
 pub mod graph_node;

--- a/layercake-server/src/graphql/types/mod.rs
+++ b/layercake-server/src/graphql/types/mod.rs
@@ -9,6 +9,7 @@ pub mod data_set;
 pub mod graph;
 pub mod graph_data;
 pub mod graph_diff;
+pub mod palette;
 pub mod graph_edge;
 pub mod graph_edit;
 pub mod graph_node;

--- a/layercake-server/src/graphql/types/palette.rs
+++ b/layercake-server/src/graphql/types/palette.rs
@@ -1,0 +1,60 @@
+use async_graphql::SimpleObject;
+
+#[derive(SimpleObject)]
+pub struct PaletteSwatch {
+    pub name: String,
+    pub background_color: String,
+    pub text_color: String,
+    pub border_color: String,
+    pub contrast_ratio: f64,
+    pub passes_aa: bool,
+}
+
+#[derive(SimpleObject)]
+pub struct Palette {
+    pub name: String,
+    pub description: String,
+    pub swatches: Vec<PaletteSwatch>,
+}
+
+#[derive(SimpleObject)]
+pub struct ContrastResult {
+    pub ratio: f64,
+    pub passes_aa: bool,
+    pub passes_aa_large: bool,
+    pub passes_aaa: bool,
+}
+
+impl From<layercake_core::palette::PaletteSwatch> for PaletteSwatch {
+    fn from(s: layercake_core::palette::PaletteSwatch) -> Self {
+        Self {
+            name: s.name,
+            background_color: s.background_color,
+            text_color: s.text_color,
+            border_color: s.border_color,
+            contrast_ratio: s.contrast_ratio,
+            passes_aa: s.passes_aa,
+        }
+    }
+}
+
+impl From<layercake_core::palette::Palette> for Palette {
+    fn from(p: layercake_core::palette::Palette) -> Self {
+        Self {
+            name: p.name,
+            description: p.description,
+            swatches: p.swatches.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<layercake_core::palette::ContrastResult> for ContrastResult {
+    fn from(c: layercake_core::palette::ContrastResult) -> Self {
+        Self {
+            ratio: c.ratio,
+            passes_aa: c.passes_aa,
+            passes_aa_large: c.passes_aa_large,
+            passes_aaa: c.passes_aaa,
+        }
+    }
+}


### PR DESCRIPTION
Implements the deferred feature requests from the tool reviews, in the recommended order (self-contained first). Beads tracking initialised in this branch; each FR has a bead.

## FR7 — per-node execution timings (`d3e83425`)
`executePlan` now returns `nodeResults: [NodeExecutionTiming!]!` (nodeId, nodeType, durationMs) in topological order. `DagExecutor` accumulates a record per node (mirrors the warnings accumulator).

## FR1 — dataset diff (`5a591e64`)
New `layercake_core::graph_diff` (added/removed/changed nodes+edges by id; change = serialised content differs) + `diffDatasets(fromDatasetId, toDatasetId): GraphDiff!` query. Answers "what did the merge do?".

## FR2 — renameNode (`366c1ddf`)
`renamePlanDagNode(projectId, planId, oldId, newId)` renames a node and rewrites every reference (edges' source/target, computed graphs' dag_node_id) in one transaction. Rejects collisions.

## FR4 — palette presets + WCAG (`e5e90765`)
`layercake_core::palette`: WCAG contrast math + 3 AA-validated palettes. `palettePresets` and `checkContrast(background, text)` queries. Catches the "disappears next to a white UI" case.

## FR3a — computed-graph source picker (`8e76e65e`)
Frontend: the story datasets tab now lists computed graphs (GraphNode outputs) alongside datasets, completing the `enabledGraphIds` backend (PR #87). FR3(b) — a graphical sequence-authoring picker — remains a larger effort (bead + issue #86).

## Verification
195 core lib tests + server tests pass; workspace builds; frontend `tsc --noEmit` + production build clean. Each FR has regression tests (diff detection, rename+edge-follow, WCAG math, palette AA). API additions verified end-to-end against a live server (diffDatasets, palettePresets, checkContrast). FR3a verified via typecheck+build (no live browser in env).

## Opportunities filed as beads
- executeNode should also carry timings/warnings (symmetry with executePlan).
- Extend diffDatasets to dataset↔computed-graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)