### PR TITLE
fix: PlantUML switch bug + tool-review-003 uplift

### DIFF
--- a/docs-tool/guide/agent-runbook.md
+++ b/docs-tool/guide/agent-runbook.md
@@ -20,6 +20,9 @@ here; each row points at the workflow/guide/command with the detail.
 | Drive a running server over HTTP | `doc workflow drive-via-api`; `api call` |
 | Edit a plan DAG (nodes/edges) | `doc workflow edit-a-plan` |
 | Understand node types + their config | `doc guide node-types` |
+| Trace dataset → computed graph → exported bytes | `doc guide graph-lifecycle` |
+| List curated colour palettes / apply one in a call | `palettePresets` query; `applyPalettePreset(projectId, presetName)` mutation |
+| Check a colour pair passes WCAG before using it | `checkContrast(background, text)` query |
 | Know the `graphJson` shape for datasets | `doc guide graph-json` |
 | Author a story → sequence diagram | `doc workflow develop-a-story` |
 | Source a story from a merged graph | `develop-a-story` (§ `enabledGraphIds`) |
@@ -44,3 +47,13 @@ here; each row points at the workflow/guide/command with the detail.
 - Sequence notes render only when `renderConfig.showNotes` is true; an unset
   `notePosition` means `Both`.
 - `execute*` results now carry a `warnings` array — check it.
+
+## Common pitfalls (symptom → cause → fix)
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Diagram renders empty (no error) | Stale/missing computed graph for the artefact's source node | `layercake doctor --project <id>`; re-execute the producing Graph/Merge/Transform node (see `doc guide graph-lifecycle`) |
+| A `.mmd` output contains `@startuml` (or `.puml` contains `sequenceDiagram`) | `renderTarget` was switched but `outputPath` extension stayed stale | Now guarded: the server rejects a mismatched target/extension, and the UI rewrites the extension on switch. Set `outputPath` extension to match the target (`.mmd`/`.md` for Mermaid, `.puml`/`.txt` for PlantUML) |
+| `mmdc` rejects the rendered output | Stray semicolons in labels breaking Mermaid syntax | Now neutralised in the templates; re-render |
+| `doctor` errors "database file does not exist" or resolves the wrong DB | Run from a different cwd than the server with a relative `--database` | `doctor` resolves a running server's **absolute** path via `/health`; pass `--port`/`--url`, or give an absolute `--database` |
+| `api call` with a hex colour silently drops/garbles it | Unquoted `#rrggbb` in `--variables` — `#` starts a shell comment, and bare hex isn't valid JSON | Quote hex as a JSON string and pass variables via a file: `--variables @vars.json` with `{"backgroundColor": "1f2937"}` (colours are stored without the leading `#`) |

--- a/docs-tool/guide/graph-lifecycle.md
+++ b/docs-tool/guide/graph-lifecycle.md
@@ -1,0 +1,43 @@
+# Guide: Graph lifecycle
+
+How a dataset becomes exported diagram bytes, and where a `graph_data` row is
+created, invalidated, and pruned along the way. Read this when a diagram is
+empty, a graph looks stale, or you're cleaning up orphans.
+
+## The pipeline, stage by stage
+
+```
+dataset  →  DataSetNode  →  GraphNode / MergeNode / TransformNode  →  graph_data row  →  GraphArtefactNode  →  exported bytes
+```
+
+| Stage | What it is | Graph state |
+|-------|------------|-------------|
+| **dataset** | Imported rows (nodes/edges/layers), addressed by PK. | No graph yet — raw source data. |
+| **DataSetNode** | A DAG node that references a dataset (`linkedDataSetId`). | Names a source; still no computed graph. |
+| **GraphNode / MergeNode / TransformNode** | Compute nodes: build/merge/transform a graph from upstream. | Executing one **creates or refreshes** a `graph_data` row keyed by `(project_id, dag_node_id)`. |
+| **`graph_data` row** | The materialised graph for that DAG node — the computed-graph cache. | Exists once its producing node has executed. |
+| **GraphArtefactNode** (also Tree/Sequence artefacts) | Render nodes: read a `graph_data` row and render a diagram. | Reads, does not create, graph state. |
+| **exported bytes** | The rendered `.mmd`/`.puml`/… written to `outputPath`. | Terminal output. |
+
+## Created / invalidated / pruned
+
+- **Created / refreshed** — when a compute node (Graph/Merge/Transform) executes,
+  its `graph_data` row is written (upsert on `dag_node_id`). Re-running replaces it.
+- **Invalidated** — editing a compute node or its upstream leaves the old
+  `graph_data` row in place until the node re-executes; a render reading a stale
+  row is the usual cause of a "green but wrong/empty" diagram. Re-execute the
+  producing node.
+- **Origin rewritten** — `renamePlanDagNode` rewrites `graph_data.dag_node_id`
+  so a computed graph follows its node's new id (no orphan created by a rename).
+- **Pruned** — a `graph_data` row whose `dag_node_id` no longer matches any node
+  in the plan is an **orphan** (e.g. the producing node was deleted). Clean these
+  with the `pruneOrphanedGraphs(projectId)` mutation.
+
+## Diagnosing
+
+- **Empty or stale diagram** → run `layercake doctor --project <id>`. It flags
+  missing/stale `graph_data` and orphaned graphs, and resolves the DB from a
+  running server so it works regardless of cwd.
+- **Orphaned graphs after deleting nodes** → `pruneOrphanedGraphs(projectId)`.
+- **Which node produced a graph** → `graph_data.dag_node_id` is the producing
+  DAG node's id.

--- a/frontend/src/components/editors/PlanVisualEditor/forms/SequenceArtefactNodeConfigForm.tsx
+++ b/frontend/src/components/editors/PlanVisualEditor/forms/SequenceArtefactNodeConfigForm.tsx
@@ -38,6 +38,23 @@ const buildInitialConfig = (rawConfig: SequenceArtefactNodeConfig): SequenceArte
   useStoryLayers: rawConfig.useStoryLayers ?? true,
 });
 
+// The server rejects a renderTarget whose outputPath extension doesn't match
+// (MermaidSequence → .mmd/.md, PlantUmlSequence → .puml/.txt). Keep the two in
+// sync so switching the target doesn't produce a save error.
+const extensionForTarget = (target: SequenceArtefactRenderTarget): string =>
+  target === 'PlantUmlSequence' ? 'puml' : 'mmd';
+
+const syncOutputPathExtension = (
+  outputPath: string,
+  target: SequenceArtefactRenderTarget
+): string => {
+  if (!outputPath) return outputPath; // empty → server auto-generates
+  const ext = extensionForTarget(target);
+  return /\.[^./\\]+$/.test(outputPath)
+    ? outputPath.replace(/\.[^./\\]+$/, `.${ext}`) // swap existing extension
+    : `${outputPath}.${ext}`; // append when none
+};
+
 export const SequenceArtefactNodeConfigForm: React.FC<SequenceArtefactNodeConfigFormProps> = ({
   config,
   setConfig,
@@ -265,10 +282,16 @@ export const SequenceArtefactNodeConfigForm: React.FC<SequenceArtefactNodeConfig
             <Select
               value={localConfig.renderTarget}
               onValueChange={(value) =>
-                updateConfigState(prev => ({
-                  ...prev,
-                  renderTarget: value as SequenceArtefactRenderTarget,
-                }))
+                updateConfigState(prev => {
+                  const renderTarget = value as SequenceArtefactRenderTarget;
+                  return {
+                    ...prev,
+                    renderTarget,
+                    // Keep the output extension consistent with the target so
+                    // the server's renderTarget↔extension validation passes.
+                    outputPath: syncOutputPathExtension(prev.outputPath, renderTarget),
+                  };
+                })
               }
             >
               <SelectTrigger id="render-target">

--- a/layercake-cli/src/api.rs
+++ b/layercake-cli/src/api.rs
@@ -37,8 +37,15 @@ struct ApiInfo {
     detected_ports: Vec<u16>,
 }
 
-/// Probe `/health` at a base URL; return the reported version on success.
-async fn probe_health(base: &str) -> Option<String> {
+/// The subset of `/health` we consume.
+struct HealthInfo {
+    version: String,
+    /// The (absolute) database path the server reports, if any.
+    database: Option<String>,
+}
+
+/// Probe `/health` at a base URL; return its info on success.
+async fn probe_health(base: &str) -> Option<HealthInfo> {
     let client = reqwest::Client::builder()
         .timeout(Duration::from_millis(600))
         .build()
@@ -48,13 +55,17 @@ async fn probe_health(base: &str) -> Option<String> {
         return None;
     }
     let body: serde_json::Value = resp.json().await.ok()?;
-    // Treat any healthy JSON as reachable; surface version if present.
-    Some(
-        body.get("version")
+    Some(HealthInfo {
+        version: body
+            .get("version")
             .and_then(|v| v.as_str())
             .unwrap_or("unknown")
             .to_string(),
-    )
+        database: body
+            .get("database")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+    })
 }
 
 /// Print the endpoints and headers for a running server, verifying against a
@@ -69,8 +80,15 @@ pub async fn info(
     let base = base_url(url, host, port);
     let ws_base = base.replacen("http", "ws", 1);
 
-    let server_version = probe_health(&base).await;
-    let reachable = server_version.is_some();
+    let health = probe_health(&base).await;
+    let reachable = health.is_some();
+    // Prefer the server's (absolute) database path when reachable; fall back to
+    // the CLI's --database value otherwise.
+    let database_display = health
+        .as_ref()
+        .and_then(|h| h.database.clone())
+        .unwrap_or_else(|| database.to_string());
+    let server_version = health.as_ref().map(|h| h.version.clone());
 
     // If the requested endpoint isn't answering, scan a few common local ports
     // so the user isn't stuck on the "wrong port" trap.
@@ -93,7 +111,7 @@ pub async fn info(
         health: format!("{}/health", base),
         collaboration_ws: format!("{}/ws/collaboration?project_id=<N>", ws_base),
         session_header: "x-layercake-session",
-        database: database.to_string(),
+        database: database_display,
         base_url: base,
         reachable,
         server_version,

--- a/layercake-cli/src/doctor.rs
+++ b/layercake-cli/src/doctor.rs
@@ -1,9 +1,20 @@
 //! `layercake doctor` — scan a project for structural health problems.
 
 use anyhow::{anyhow, Result};
-use layercake_core::database::connection::{establish_connection, get_database_url};
+use layercake_core::database::connection::establish_connection;
 use layercake_core::doctor::{run_diagnostics, Severity};
+use sea_orm::{ConnectionTrait, DatabaseConnection, Statement};
 use std::time::Duration;
+
+/// Whether a table exists in the connected SQLite database.
+async fn has_table(db: &DatabaseConnection, name: &str) -> Result<bool> {
+    let stmt = Statement::from_sql_and_values(
+        db.get_database_backend(),
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        [name.into()],
+    );
+    Ok(db.query_one(stmt).await?.is_some())
+}
 
 /// Resolve the database path: explicit `--database` wins; otherwise ask a
 /// running server's `/health` (so `doctor --project N` works cwd-independently
@@ -58,7 +69,32 @@ pub async fn run(
     json: bool,
 ) -> Result<()> {
     let database = resolve_database(database, url, host, port).await?;
-    let db = establish_connection(&get_database_url(Some(&database))).await?;
+
+    // Never create a database by resolving to a wrong/relative path — the file
+    // must already exist, and open it read-only so diagnostics can't mutate it.
+    if database != ":memory:" && !std::path::Path::new(&database).exists() {
+        return Err(anyhow!(
+            "database file does not exist: {}\n(if a server is running, pass --port/--url so \
+             doctor resolves its absolute path, or pass an absolute --database)",
+            database
+        ));
+    }
+    let db_url = if database == ":memory:" {
+        "sqlite::memory:".to_string()
+    } else {
+        format!("sqlite://{}?mode=ro", database)
+    };
+    let db = establish_connection(&db_url).await?;
+
+    // Sentinel: a real layercake DB has a `plans` table. Fail clearly rather
+    // than propagating a raw "no such table" from a check.
+    if !has_table(&db, "plans").await? {
+        return Err(anyhow!(
+            "this doesn't look like a layercake database (no 'plans' table): {}",
+            database
+        ));
+    }
+
     let report = run_diagnostics(&db, project).await?;
 
     let warning_count = report

--- a/layercake-core/src/pipeline/dag_executor.rs
+++ b/layercake-core/src/pipeline/dag_executor.rs
@@ -32,12 +32,36 @@ pub struct DagExecutor {
     node_records: std::sync::Arc<std::sync::Mutex<Vec<NodeExecutionRecord>>>,
 }
 
+/// Which phase a node's work happens in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecutionPhase {
+    /// Ran during `executePlan` (import/build/merge/transform).
+    Execute,
+    /// Rendered lazily on `exportNodeOutput`; `duration_ms` here is 0 because
+    /// no work happens during `executePlan`.
+    Render,
+}
+
+impl ExecutionPhase {
+    /// Classify a node by type: artefact nodes render lazily, everything else
+    /// runs during execution.
+    fn for_node_type(node_type: &str) -> Self {
+        match node_type {
+            "GraphArtefactNode" | "TreeArtefactNode" | "SequenceArtefactNode" | "ProjectionNode" => {
+                ExecutionPhase::Render
+            }
+            _ => ExecutionPhase::Execute,
+        }
+    }
+}
+
 /// Timing/outcome for a single node executed during a DAG run.
 #[derive(Debug, Clone)]
 pub struct NodeExecutionRecord {
     pub node_id: String,
     pub node_type: String,
     pub duration_ms: u64,
+    pub phase: ExecutionPhase,
 }
 
 /// Options for creating or updating graph_data records originating from DAG nodes
@@ -1376,10 +1400,12 @@ impl DagExecutor {
                 .find(|n| n.id == node_id)
                 .map(|n| n.node_type.clone())
                 .unwrap_or_default();
+            let phase = ExecutionPhase::for_node_type(&node_type);
             self.push_node_record(NodeExecutionRecord {
                 node_id: node_id.clone(),
                 node_type,
                 duration_ms: started.elapsed().as_millis() as u64,
+                phase,
             });
         }
 

--- a/layercake-core/src/pipeline/mod.rs
+++ b/layercake-core/src/pipeline/mod.rs
@@ -8,7 +8,7 @@ mod merge_builder;
 #[allow(dead_code)]
 mod types;
 
-pub use dag_executor::{DagExecutor, NodeExecutionRecord};
+pub use dag_executor::{DagExecutor, ExecutionPhase, NodeExecutionRecord};
 pub use dataset_importer::DatasourceImporter;
 pub use graph_data_builder::GraphDataBuilder;
 pub use merge_builder::MergeBuilder;

--- a/layercake-core/tests/project_archive_roundtrip.rs
+++ b/layercake-core/tests/project_archive_roundtrip.rs
@@ -118,6 +118,7 @@ async fn project_export_import_roundtrip_restores_assets() -> Result<()> {
         description: Set(Some("roundtrip story".to_string())),
         tags: Set(json!(["critical"]).to_string()),
         enabled_dataset_ids: Set(json!([dataset.id]).to_string()),
+        enabled_graph_ids: Set(json!([]).to_string()),
         layer_config: Set(json!({ "layer-1": { "visible": true } }).to_string()),
         created_at: Set(now),
         updated_at: Set(now),

--- a/layercake-server/src/graphql/mutations/helpers.rs
+++ b/layercake-server/src/graphql/mutations/helpers.rs
@@ -514,12 +514,33 @@ pub struct PlanExecutionResult {
     pub node_results: Vec<NodeExecutionTiming>,
 }
 
+/// Which phase a node's work happens in.
+#[derive(async_graphql::Enum, Copy, Clone, Eq, PartialEq)]
+pub enum ExecutionPhase {
+    /// Ran during executePlan (import/build/merge/transform).
+    Execute,
+    /// Rendered lazily on exportNodeOutput; durationMs is 0 during executePlan.
+    Render,
+}
+
+impl From<layercake_core::pipeline::ExecutionPhase> for ExecutionPhase {
+    fn from(p: layercake_core::pipeline::ExecutionPhase) -> Self {
+        match p {
+            layercake_core::pipeline::ExecutionPhase::Execute => ExecutionPhase::Execute,
+            layercake_core::pipeline::ExecutionPhase::Render => ExecutionPhase::Render,
+        }
+    }
+}
+
 /// Timing for a single node in a plan execution.
 #[derive(async_graphql::SimpleObject)]
 pub struct NodeExecutionTiming {
     pub node_id: String,
     pub node_type: String,
     pub duration_ms: i64,
+    /// Whether the node ran during execution or renders lazily on export.
+    /// Artefact nodes are `Render` (durationMs 0 here).
+    pub phase: ExecutionPhase,
 }
 
 impl From<layercake_core::pipeline::NodeExecutionRecord> for NodeExecutionTiming {
@@ -528,6 +549,7 @@ impl From<layercake_core::pipeline::NodeExecutionRecord> for NodeExecutionTiming
             node_id: r.node_id,
             node_type: r.node_type,
             duration_ms: r.duration_ms as i64,
+            phase: r.phase.into(),
         }
     }
 }

--- a/layercake-server/src/graphql/mutations/layer.rs
+++ b/layercake-server/src/graphql/mutations/layer.rs
@@ -39,6 +39,61 @@ impl LayerMutation {
         Ok(ProjectLayer::from(model))
     }
 
+    /// Apply a curated palette preset in one call: upsert each of the preset's
+    /// swatches as a project layer (keyed by swatch name). Returns the resulting
+    /// project layers. Fails if `presetName` is not a known preset.
+    #[graphql(name = "applyPalettePreset")]
+    async fn apply_palette_preset(
+        &self,
+        ctx: &Context<'_>,
+        project_id: i32,
+        preset_name: String,
+    ) -> Result<Vec<ProjectLayer>> {
+        let context = ctx.data::<GraphQLContext>()?;
+        let actor = context.actor_for_request(ctx).await;
+
+        let preset = layercake_core::palette::presets()
+            .into_iter()
+            .find(|p| p.name == preset_name)
+            .ok_or_else(|| {
+                let names = layercake_core::palette::presets()
+                    .iter()
+                    .map(|p| p.name.clone())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                Error::new(format!(
+                    "unknown palette preset '{}' (available: {})",
+                    preset_name, names
+                ))
+            })?;
+
+        // Colours are stored without a leading '#', matching upsertProjectLayer.
+        let strip = |c: &str| c.trim_start_matches('#').to_string();
+
+        let mut layers = Vec::with_capacity(preset.swatches.len());
+        for swatch in &preset.swatches {
+            let model = context
+                .app
+                .upsert_project_layer(
+                    &actor,
+                    project_id,
+                    swatch.name.clone(),
+                    swatch.name.clone(),
+                    strip(&swatch.background_color),
+                    strip(&swatch.text_color),
+                    strip(&swatch.border_color),
+                    None,
+                    None,
+                    true,
+                )
+                .await
+                .map_err(crate::graphql::errors::core_error_to_graphql_error)?;
+            layers.push(ProjectLayer::from(model));
+        }
+
+        Ok(layers)
+    }
+
     /// Delete a project layer entry (optionally scoped to a source dataset row)
     #[graphql(name = "deleteProjectLayer")]
     async fn delete_project_layer(

--- a/layercake-server/src/graphql/mutations/plan_dag_nodes.rs
+++ b/layercake-server/src/graphql/mutations/plan_dag_nodes.rs
@@ -111,9 +111,18 @@ impl PlanDagNodesMutation {
         Ok(Some(PlanDagNode::from(updated)))
     }
 
-    /// Rename a Plan DAG node to a new (human-readable) id. Rewrites every
-    /// reference: connected edges and any computed graph's origin. Fails if the
-    /// new id already exists in the plan.
+    /// Rename a Plan DAG node to a new (human-readable) id.
+    ///
+    /// Behaviour:
+    /// - No-op when `newId == oldId`: returns the current node unchanged.
+    /// - Rejects an empty `newId`, and rejects a `newId` that already exists in
+    ///   the plan (collision).
+    /// - Errors if `oldId` is not found in the plan.
+    /// - In one transaction, rewrites every reference to the node: connected
+    ///   edges (both source and target endpoints) and any computed graph's
+    ///   origin (`graph_data.dag_node_id`).
+    /// - Bumps the plan version (like `updatePlanDagNode`), so collaborators
+    ///   receive the change via the plan-update WS event.
     #[graphql(name = "renamePlanDagNode")]
     async fn rename_plan_dag_node(
         &self,

--- a/layercake-server/src/server/mod.rs
+++ b/layercake-server/src/server/mod.rs
@@ -44,7 +44,20 @@ pub async fn start_server(
         Err(e) => warn!("Failed to reconcile interrupted graph executions: {}", e),
     }
 
-    let app = app::create_app(db, cors_origin, database_path.to_string()).await?;
+    // Report an absolute database path so tools that resolve it from a
+    // different working directory (e.g. `layercake doctor --port N`) open the
+    // right file. The file exists by now (migrations ran above), so
+    // canonicalize succeeds; fall back to the raw value for `:memory:` or edge
+    // cases.
+    let absolute_database_path = if database_path == ":memory:" {
+        database_path.to_string()
+    } else {
+        std::fs::canonicalize(database_path)
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|_| database_path.to_string())
+    };
+
+    let app = app::create_app(db, cors_origin, absolute_database_path).await?;
 
     // Log all HTTP routes dynamically
     log_routes(port);

--- a/plans/20260716-tool-review-003-uplift.md
+++ b/plans/20260716-tool-review-003-uplift.md
@@ -1,0 +1,61 @@
+# Uplift plan — tool-review-003
+
+**Date:** 2026-07-16
+**Source:** `reviews/tool-review-003.md` (third pass, project 36). Mostly green — verifies the two prior uplifts landed. Small actionable set; N3/N9 is the one real regression.
+**Approach:** structural over patches. Validate every finding against master first (done below).
+
+## Validation (against master)
+
+| # | Finding | Verdict | Notes |
+|---|---------|---------|-------|
+| **N3/N9** | `/health` + `api info` report a **relative** DB path | **CONFIRMED, the one real bug** | `health.rs` echoes `state.database_path` (raw `--database` literal). `doctor --port N` from another cwd then resolves it relative → creates a wrong empty DB → "no such table: plans". |
+| **N3b / Rec2** | doctor uses `mode=rwc` (creates empty DB) and doesn't check for `plans` | **CONFIRMED** | `doctor.rs` connects via `get_database_url` (rwc) with no table check. |
+| **N14** | `renamePlanDagNode` SDL comment doesn't state collision/idempotency/WS semantics | **CONFIRMED** | Behaviour is correct (rejects collision, no-op on equal — tested in FR2), just undocumented in SDL. |
+| **N12** | `NodeExecutionTiming` has no `phase`; artefact nodes read 0ms (lazy render) | **CONFIRMED** | `helpers.rs` — only nodeId/nodeType/durationMs. Add `phase` to disambiguate execute vs render. |
+| **N13** | No `guide graph-lifecycle` | CONFIRMED (docs) | dataset→node→graph_data→artefact lifecycle only in commit msgs. |
+| **N10** | checkContrast + quoting note | CONFIRMED (docs) | one line in FR4/palette doc. |
+| **Rec3** | `applyPalettePreset` mutation | CONFIRMED (gap) | `palettePresets` exists; no one-shot apply. Low priority but self-contained + high-value. |
+| **Rec4** | agent-runbook "common pitfalls" section | CONFIRMED (docs) | turn every review bug into a runbook line. |
+| **Rec5** | structured warnings (`type Warning{code,message,nodeId,severity}`) | Deferred | "not urgent — free strings usable". Larger; evaluate, likely defer. |
+| **N11** | swatch contrast only for its own bg/text pair | Won't-fix (by design) | reviewer agrees it's fine. |
+| **FR3b** | CLI story shorthands (`story list`) | Deferred | tracked; UI exists. |
+| **doctor --fix** | remediation | Deferred | issue #89 already filed; could call pruneOrphanedGraphs. Evaluate. |
+
+## Stages
+
+### Stage 1 — N3/N9: report the absolute DB path [CORRECTNESS, the real fix]
+Canonicalise the database path server-side so `/health` and `api info` report an absolute path.
+- `health.rs`: report `std::fs::canonicalize(state.database_path)` (fall back to the raw value if the file doesn't exist yet), so `doctor --port N` resolves the right file from any cwd.
+- `api info`: same — print the absolute DB path.
+**Status:** Not Started
+
+### Stage 2 — N3b/Rec2: doctor refuses a no-tables / non-layercake DB [CORRECTNESS]
+- When doctor auto-resolves a DB (no explicit `--database`), open **read-only** so it never creates an empty file.
+- Before running checks, verify the DB has a `plans` table (or similar sentinel); if not, error "this doesn't look like a layercake database (no 'plans' table): <path>" rather than propagating the raw SQLite error.
+**Status:** Not Started
+
+### Stage 3 — N12: phase on NodeExecutionTiming [CLARITY]
+Add `phase: ExecutionPhase` (`Execute` | `Render`) to `NodeExecutionTiming` (artefact nodes render lazily on export, so they read 0ms during executePlan — mark them `Render`/skipped so the 0 isn't misleading). Or, minimally, a doc comment + a boolean. Prefer the enum.
+**Status:** Not Started
+
+### Stage 4 — N14: renamePlanDagNode SDL comment [DOCS/SCHEMA]
+Expand the mutation's doc comment to state: rejects a colliding `newId`; no-op when `newId == oldId`; rewrites incident edges + computed-graph origins. (WS-event parity: verify whether it bumps plan version like updatePlanDagNode — it does via `bump_plan_version`; note it.)
+**Status:** Not Started
+
+### Stage 5 — Rec3: applyPalettePreset mutation [FEATURE, self-contained]
+`applyPalettePreset(projectId, presetName): [ProjectLayer!]!` — upsert the preset's swatches as project layers in one call. Reuses `palette::presets()` + the existing layer upsert. Closes the "one-click apply" gap.
+**Status:** Not Started
+
+### Stage 6 — Docs: graph-lifecycle guide + runbook pitfalls + N10 [DOCS]
+- `doc guide graph-lifecycle` (N13): dataset → DataSetNode → GraphNode/Merge/Transform → `graph_data` row → GraphArtefactNode → exported bytes; created/invalidated/pruned per stage; ties in `pruneOrphanedGraphs` + doctor.
+- agent-runbook "Common pitfalls" (Rec4): empty diagram → doctor; `.mmd` contains `@startuml` → renderTarget drift (now validated); mmdc rejects output → semicolons (now neutralised); wrong-cwd doctor → absolute path now reported.
+- N10: one line in the palette/FR4 doc about quoting hex via `--variables`.
+**Status:** Not Started
+
+## Deferred / file as beads
+- Rec5 structured warnings — evaluate; likely a bead (behaviour-shaping, larger).
+- doctor --fix (#89), FR3b CLI shorthands, dataset↔graph diff (bead layercake-tool-0li) — carry.
+- N11 won't-fix.
+
+## Guiding principle
+Structural: fix the seam (absolute path at the source, not per-caller patching); make failures visible (doctor refuses a bad DB instead of a cryptic SQLite error). N3/N9 is the priority — it's the one thing keeping the reviewer from "all green".


### PR DESCRIPTION
## Summary

Fixes a user-reported bug (switching a story sequence to PlantUML fails to save) and implements the tool-review-003 uplift.

### Bug fix — PlantUML switch (layercake-tool-io5)
Switching a story sequence artefact to PlantUML failed to save: the server's `renderTarget`↔extension validation rejects `PlantUmlSequence` with a `.mmd` outputPath, but the form only updated `renderTarget` and left the extension stale. The form now rewrites the extension (`.mmd`↔`.puml`) whenever the target changes, keeping the two in sync.

### Review-003 uplift stages
- **N3/N9** (prior commit) — server canonicalises the DB path so `/health`, `doctor`, and `api info` report an absolute path (cwd-independent).
- **N3b/Rec2** (prior commit) — `doctor` refuses a missing/no-tables DB and opens read-only.
- **N12** — `ExecutionPhase` (Execute/Render) on node execution timings, exposed via GraphQL `NodeExecutionTiming.phase`.
- **N14** — expanded `renamePlanDagNode` SDL doc (no-op/collision/edge+origin-rewrite/version-bump).
- **Rec3** — new `applyPalettePreset(projectId, presetName)` mutation: one-call upsert of a curated preset's swatches as project layers.
- **N13/Rec4/N10** — new `graph-lifecycle` guide; runbook Common-pitfalls table (empty diagram, renderTarget/extension drift, mmdc semicolons, doctor cwd, hex-quoting via `--variables`).

### Incidental
- Unblocked the test suite: added `enabled_graph_ids` to a story `ActiveModel` in `project_archive_roundtrip` (pre-existing compile drift from the F7 schema change).
- Filed layercake-tool-4dy for a **pre-existing** `reference_exports` golden-file failure that also fails on master (unrelated to this branch).

## Testing
- `cargo build --workspace` ✓
- `cargo test --workspace` ✓ (all green except the pre-existing `reference_exports`, tracked separately)
- `tsc --noEmit` + `frontend:build` ✓
- Verified `applyPalettePreset` and `renamePlanDagNode` appear in `schema dump`; both new guides print via `doc guide`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)