### PR TITLE
refactor(apollo): migrate to Apollo Client 4.2 via TypedDocumentNode

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@apollo/client": "^4.0.5",
+        "@apollo/client": "^4.2.7",
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-avatar": "^1.1.11",
@@ -101,15 +101,10 @@
       }
     },
     "node_modules/@apollo/client": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-4.0.5.tgz",
-      "integrity": "sha512-H0FQXa6MRWQS0/jNv4VO6NfUWueZ4L7QYjkbSztADpugb4yTzRBVVwFq5mL3FJVJWewxWVrzJof/yzCTVTsXaw==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-4.2.7.tgz",
+      "integrity": "sha512-Z129zR77VP0oWWIXPpHgwbtwhCVBzkw/FhiiymbqwlUniKb5z2KBeuQkpNIz3QfuO7ezHiaxsJ0PPjYBJTSHtg==",
       "license": "MIT",
-      "workspaces": [
-        "dist",
-        "codegen",
-        "scripts/codemods/ac3-to-ac4"
-      ],
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "@wry/caches": "^1.0.0",
@@ -120,7 +115,7 @@
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "graphql": "^16.0.0",
+        "graphql": "^16.0.0 || ^17.0.0",
         "graphql-ws": "^5.5.5 || ^6.0.3",
         "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc",
         "react-dom": "^17.0.0 || ^18.0.0 || >=19.0.0-rc",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,7 @@
     "vite": "^7.1.6"
   },
   "dependencies": {
-    "@apollo/client": "^4.0.5",
+    "@apollo/client": "^4.2.7",
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-avatar": "^1.1.11",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react'
 import { Routes, Route, Navigate, useNavigate, useParams, useLocation, Link } from 'react-router-dom'
 import { IconGraph, IconServer, IconDatabase, IconPlus, IconSettings, IconFileDatabase, IconTrash, IconDownload, IconChevronLeft, IconChevronRight, IconFolderPlus, IconBooks, IconAdjustments, IconHierarchy2, IconChevronDown, IconUpload, IconFlask } from '@tabler/icons-react'
 import { useQuery, useMutation } from '@apollo/client/react'
-import { gql } from '@apollo/client'
+import { gql, type TypedDocumentNode } from '@apollo/client'
 import { Breadcrumbs } from './components/common/Breadcrumbs'
 import { PlanVisualEditor } from './components/editors/PlanVisualEditor/PlanVisualEditor'
 import { ErrorBoundary } from './components/common/ErrorBoundary'
@@ -31,13 +31,12 @@ import { cn } from './lib/utils'
 import { useTagsFilter } from './hooks/useTagsFilter'
 import { EXPORT_PROJECT_ARCHIVE, EXPORT_PROJECT_AS_TEMPLATE, RESET_PROJECT } from './graphql/libraryItems'
 import { LIST_PLANS, GET_PLAN } from './graphql/plans'
-import { LIST_STORIES, type Story } from './graphql/stories'
+import { LIST_STORIES } from './graphql/stories'
 import { showErrorNotification, showSuccessNotification } from './utils/notifications'
 import { PlansPage } from './components/plans/PlansPage'
 import { ProjectionsPage } from './pages/workbench/ProjectionsPage'
 import { ProjectionViewerPage } from './pages/projections/ProjectionViewerPage'
 import { ProjectionEditPage } from './pages/projections/ProjectionEditPage'
-import type { Plan } from './types/plan'
 
 // Collaboration Context for providing project-level collaboration to all pages
 const CollaborationContext = React.createContext<any>(null)
@@ -59,8 +58,36 @@ type ProjectNavSection = {
   children?: ProjectNavChild[]
 }
 
+// Shape of a project as returned by the queries/mutations in this file
+type ProjectSummary = {
+  id: number
+  name: string
+  description: string
+  importExportPath?: string | null
+  tags: string[]
+  createdAt: string
+  updatedAt: string
+}
+
+// Reduced project shape returned by import/export mutations
+type ProjectImportExportResult = {
+  id: number
+  name: string
+  description: string
+  importExportPath?: string | null
+}
+
+type SampleProjectSummary = {
+  key: string
+  name: string
+  description?: string | null
+}
+
 // Query to fetch projects
-const GET_PROJECTS = gql`
+const GET_PROJECTS: TypedDocumentNode<
+  { projects: ProjectSummary[] },
+  { tags?: string[] | null }
+> = gql`
   query GetProjects($tags: [String!]) {
     projects(tags: $tags) {
       id
@@ -75,13 +102,19 @@ const GET_PROJECTS = gql`
 `
 
 // Mutation to delete a project
-const DELETE_PROJECT = gql`
+const DELETE_PROJECT: TypedDocumentNode<
+  { deleteProject: boolean },
+  { id: string | number }
+> = gql`
   mutation DeleteProject($id: ID!) {
     deleteProject(id: $id)
   }
 `
 
-const GET_SAMPLE_PROJECTS = gql`
+const GET_SAMPLE_PROJECTS: TypedDocumentNode<
+  { sampleProjects: SampleProjectSummary[] },
+  Record<string, never>
+> = gql`
   query GetSampleProjects {
     sampleProjects {
       key
@@ -91,7 +124,10 @@ const GET_SAMPLE_PROJECTS = gql`
   }
 `
 
-const CREATE_SAMPLE_PROJECT = gql`
+const CREATE_SAMPLE_PROJECT: TypedDocumentNode<
+  { createSampleProject: { id: number; name: string; description?: string | null } },
+  { sampleKey: string }
+> = gql`
   mutation CreateSampleProject($sampleKey: String!) {
     createSampleProject(sampleKey: $sampleKey) {
       id
@@ -101,7 +137,10 @@ const CREATE_SAMPLE_PROJECT = gql`
   }
 `
 
-const IMPORT_PROJECT_ARCHIVE = gql`
+const IMPORT_PROJECT_ARCHIVE: TypedDocumentNode<
+  { importProjectArchive: ProjectImportExportResult },
+  { fileContent: string; name?: string | null }
+> = gql`
   mutation ImportProjectArchive($fileContent: String!, $name: String) {
     importProjectArchive(fileContent: $fileContent, name: $name) {
       id
@@ -112,7 +151,10 @@ const IMPORT_PROJECT_ARCHIVE = gql`
   }
 `
 
-const IMPORT_PROJECT_FROM_DIRECTORY = gql`
+const IMPORT_PROJECT_FROM_DIRECTORY: TypedDocumentNode<
+  { importProjectFromDirectory: ProjectImportExportResult },
+  { path: string; name?: string | null; keepConnection?: boolean | null }
+> = gql`
   mutation ImportProjectFromDirectory($path: String!, $name: String, $keepConnection: Boolean) {
     importProjectFromDirectory(path: $path, name: $name, keepConnection: $keepConnection) {
       id
@@ -123,7 +165,10 @@ const IMPORT_PROJECT_FROM_DIRECTORY = gql`
   }
 `
 
-const EXPORT_PROJECT_TO_DIRECTORY = gql`
+const EXPORT_PROJECT_TO_DIRECTORY: TypedDocumentNode<
+  { exportProjectToDirectory: boolean },
+  { projectId: number; path: string; keepConnection?: boolean | null }
+> = gql`
   mutation ExportProjectToDirectory(
     $projectId: Int!
     $path: String!
@@ -137,7 +182,10 @@ const EXPORT_PROJECT_TO_DIRECTORY = gql`
   }
 `
 
-const REIMPORT_PROJECT = gql`
+const REIMPORT_PROJECT: TypedDocumentNode<
+  { reimportProject: ProjectImportExportResult },
+  { projectId: number }
+> = gql`
   mutation ReimportProject($projectId: Int!) {
     reimportProject(projectId: $projectId) {
       id
@@ -148,14 +196,20 @@ const REIMPORT_PROJECT = gql`
   }
 `
 
-const REEXPORT_PROJECT = gql`
+const REEXPORT_PROJECT: TypedDocumentNode<
+  { reexportProject: boolean },
+  { projectId: number }
+> = gql`
   mutation ReexportProject($projectId: Int!) {
     reexportProject(projectId: $projectId)
   }
 `
 
 // Query to fetch Plan DAG for download
-const GET_PLAN_DAG = gql`
+const GET_PLAN_DAG: TypedDocumentNode<
+  { getPlanDag: unknown },
+  { projectId: number }
+> = gql`
   query GetPlanDag($projectId: Int!) {
     getPlanDag(projectId: $projectId) {
       version
@@ -637,29 +691,13 @@ const HomePage = () => {
   const [sampleError, setSampleError] = useState<string | null>(null)
   const fileInputRef = React.useRef<HTMLInputElement>(null)
 
-  const { data: projectsData } = useQuery<{
-    projects: Array<{
-      id: number
-      name: string
-      description: string
-      importExportPath?: string | null
-      tags: string[]
-      createdAt: string
-      updatedAt: string
-    }>
-  }>(GET_PROJECTS, {
+  const { data: projectsData } = useQuery(GET_PROJECTS, {
     variables: {
       tags: activeTags.length > 0 ? activeTags : null
     }
   })
 
-  const { data: sampleProjectsData, loading: sampleProjectsLoading } = useQuery<{
-    sampleProjects: Array<{
-      key: string
-      name: string
-      description?: string | null
-    }>
-  }>(GET_SAMPLE_PROJECTS)
+  const { data: sampleProjectsData, loading: sampleProjectsLoading } = useQuery(GET_SAMPLE_PROJECTS)
 
   const [createSampleProject, { loading: createSampleLoading }] = useMutation(CREATE_SAMPLE_PROJECT, {
     onCompleted: (result) => {
@@ -1028,30 +1066,14 @@ const ProjectsPage = () => {
   const [selectedSampleKey, setSelectedSampleKey] = useState<string | null>(null)
   const [sampleError, setSampleError] = useState<string | null>(null)
 
-  const { data: projectsData, loading: projectsLoading, error: projectsError, refetch } = useQuery<{
-    projects: Array<{
-      id: number
-      name: string
-      description: string
-      importExportPath?: string | null
-      tags: string[]
-      createdAt: string
-      updatedAt: string
-    }>
-  }>(GET_PROJECTS, {
+  const { data: projectsData, loading: projectsLoading, error: projectsError, refetch } = useQuery(GET_PROJECTS, {
     variables: {
       tags: activeTags.length > 0 ? activeTags : null
     },
     errorPolicy: 'all',
   })
 
-  const { data: sampleProjectsData, loading: sampleProjectsLoading, error: sampleProjectsError } = useQuery<{
-    sampleProjects: Array<{
-      key: string
-      name: string
-      description?: string | null
-    }>
-  }>(GET_SAMPLE_PROJECTS)
+  const { data: sampleProjectsData, loading: sampleProjectsLoading, error: sampleProjectsError } = useQuery(GET_SAMPLE_PROJECTS)
 
   const projects = projectsData?.projects || []
 
@@ -1333,16 +1355,7 @@ const ProjectDetailPage = () => {
   const { projectId } = useParams<{ projectId: string }>()
   const projectIdNum = parseInt(projectId || '0')
 
-  const { data: projectsData, loading: projectsLoading } = useQuery<{
-    projects: Array<{
-      id: number
-      name: string
-      description: string
-      importExportPath?: string | null
-      createdAt: string
-      updatedAt: string
-    }>
-  }>(GET_PROJECTS)
+  const { data: projectsData, loading: projectsLoading } = useQuery(GET_PROJECTS)
 
   const { data: planDagData } = useQuery(GET_PLAN_DAG, {
     variables: { projectId: projectIdNum },
@@ -1353,7 +1366,7 @@ const ProjectDetailPage = () => {
     skip: !projectId,
     fetchPolicy: 'cache-and-network',
   })
-  const { data: storiesData, loading: storiesLoading } = useQuery<{ stories: Story[] }>(LIST_STORIES, {
+  const { data: storiesData, loading: storiesLoading } = useQuery(LIST_STORIES, {
     variables: { projectId: projectIdNum },
     skip: !projectId,
     fetchPolicy: 'cache-and-network',
@@ -1927,16 +1940,7 @@ const PlanEditorPage = () => {
   const planIdNum = Number(planId || 0)
   const collaboration = useCollaboration()
 
-  const { data: projectsData, loading: projectsLoading } = useQuery<{
-    projects: Array<{
-      id: number
-      name: string
-      description: string
-      importExportPath?: string | null
-      createdAt: string
-      updatedAt: string
-    }>
-  }>(GET_PROJECTS)
+  const { data: projectsData, loading: projectsLoading } = useQuery(GET_PROJECTS)
 
   const {
     data: planData,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1348,7 +1348,7 @@ const ProjectDetailPage = () => {
     variables: { projectId: projectIdNum },
     skip: !projectId,
   })
-  const { data: plansData, loading: plansLoading } = useQuery<{ plans: Plan[] }>(LIST_PLANS, {
+  const { data: plansData, loading: plansLoading } = useQuery(LIST_PLANS, {
     variables: { projectId: projectIdNum },
     skip: !projectId,
     fetchPolicy: 'cache-and-network',
@@ -1942,7 +1942,7 @@ const PlanEditorPage = () => {
     data: planData,
     loading: planLoading,
     error: planError,
-  } = useQuery<{ plan: Plan | null }>(GET_PLAN, {
+  } = useQuery(GET_PLAN, {
     variables: { id: planIdNum },
     skip: !planIdNum,
     fetchPolicy: 'cache-and-network',
@@ -2045,7 +2045,7 @@ const LegacyPlanRedirect = () => {
   const navigate = useNavigate()
   const projectIdNum = Number(projectId || 0)
 
-  const { data, loading } = useQuery<{ plans: Array<{ id: number }> }>(LIST_PLANS, {
+  const { data, loading } = useQuery(LIST_PLANS, {
     variables: { projectId: projectIdNum },
     skip: !projectIdNum,
     fetchPolicy: 'network-only',

--- a/frontend/src/components/datasets/DataSetEditor.tsx
+++ b/frontend/src/components/datasets/DataSetEditor.tsx
@@ -28,7 +28,6 @@ import {
   GET_GRAPH_PAGE,
   DataSet,
   DataSetValidationResult,
-  GraphSummary,
   GraphPageSlice,
   UpdateDataSetInput,
   formatFileSize,
@@ -57,9 +56,20 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs'
 import { Textarea } from '../ui/textarea'
 import PageContainer from '../layout/PageContainer'
 
-import { gql } from '@apollo/client'
+import { gql, type TypedDocumentNode } from '@apollo/client'
 
-const GET_PROJECTS = gql`
+const GET_PROJECTS: TypedDocumentNode<
+  {
+    projects: Array<{
+      id: number
+      name: string
+      description: string
+      createdAt: string
+      updatedAt: string
+    }>
+  },
+  Record<string, never>
+> = gql`
   query GetProjects {
     projects {
       id
@@ -102,15 +112,7 @@ export const DataSetEditor: React.FC<DataSetEditorProps> = () => {
   const [validationError, setValidationError] = useState<string | null>(null)
 
   // Query for project info
-  const { data: projectsData } = useQuery<{
-    projects: Array<{
-      id: number
-      name: string
-      description: string
-      createdAt: string
-      updatedAt: string
-    }>
-  }>(GET_PROJECTS)
+  const { data: projectsData } = useQuery(GET_PROJECTS)
   const projects = projectsData?.projects || []
   const selectedProject = projects.find(p => p.id === parseInt(projectId || '0'))
 
@@ -127,7 +129,7 @@ export const DataSetEditor: React.FC<DataSetEditorProps> = () => {
     errorPolicy: 'all'
   })
 
-  const { data: summaryData } = useQuery<{ graphSummary: GraphSummary }>(GET_GRAPH_SUMMARY, {
+  const { data: summaryData } = useQuery(GET_GRAPH_SUMMARY, {
     skip: !datasetIdNum,
     variables: { datasetId: datasetIdNum }
   })
@@ -140,7 +142,7 @@ export const DataSetEditor: React.FC<DataSetEditorProps> = () => {
   const [graphOffset, setGraphOffset] = useState(0)
   const [graphLayerFilters, setGraphLayerFilters] = useState<string[]>([])
 
-  const { loading: graphPageLoading, data: graphPageData } = useQuery<{ graphPage: GraphPageSlice }>(
+  const { loading: graphPageLoading, data: graphPageData } = useQuery(
     GET_GRAPH_PAGE,
     {
       skip: !datasetIdNum,
@@ -152,9 +154,7 @@ export const DataSetEditor: React.FC<DataSetEditorProps> = () => {
   const [updateDataSet, { loading: updateLoading }] = useMutation(UPDATE_DATASOURCE)
   const [reprocessDataSet, { loading: reprocessLoading }] = useMutation(REPROCESS_DATASOURCE)
   const [updateDataSetGraphData] = useMutation(UPDATE_DATASOURCE_GRAPH_DATA)
-  const [validateDataSetMutation, { loading: validateLoading }] = useMutation<{
-    validateDataSet: DataSetValidationResult
-  }, { id: number }>(VALIDATE_DATASET)
+  const [validateDataSetMutation, { loading: validateLoading }] = useMutation(VALIDATE_DATASET)
 
   const dataSource: DataSet | null = (dataSourceData as any)?.dataSet || null
   const annotationMarkdown = useMemo(() => {

--- a/frontend/src/components/datasets/DataSetsPage.tsx
+++ b/frontend/src/components/datasets/DataSetsPage.tsx
@@ -55,9 +55,20 @@ import {
 
 import { showErrorNotification, showSuccessNotification } from '@/utils/notifications'
 
-import { gql } from '@apollo/client'
+import { gql, type TypedDocumentNode } from '@apollo/client'
 
-const GET_PROJECTS = gql`
+interface ProjectSummary {
+  id: number
+  name: string
+  description: string
+  createdAt: string
+  updatedAt: string
+}
+
+const GET_PROJECTS: TypedDocumentNode<
+  { projects: ProjectSummary[] },
+  Record<string, never>
+> = gql`
   query GetProjects {
     projects {
       id
@@ -89,15 +100,7 @@ export const DataSetsPage: React.FC<DataSetsPageProps> = () => {
   const [deleteMerged, setDeleteMerged] = useState(false)
 
   // Query for project info
-  const { data: projectsData } = useProjectsQuery<{
-    projects: Array<{
-      id: number
-      name: string
-      description: string
-      createdAt: string
-      updatedAt: string
-    }>
-  }>(GET_PROJECTS)
+  const { data: projectsData } = useProjectsQuery(GET_PROJECTS)
   const projects = projectsData?.projects || []
   const selectedProject = projects.find(p => p.id === projectNumericId)
 
@@ -132,8 +135,8 @@ export const DataSetsPage: React.FC<DataSetsPageProps> = () => {
     useMutation(IMPORT_LIBRARY_DATASETS)
   const [mergeDataSets, { loading: mergeLoading }] = useMutation(MERGE_DATASOURCES)
 
-  const dataSources: DataSet[] = (dataSourcesData as any)?.dataSets || []
-  const libraryItems: LibraryItem[] = (libraryItemsData as any)?.libraryItems || []
+  const dataSources: DataSet[] = dataSourcesData?.dataSets || []
+  const libraryItems: LibraryItem[] = libraryItemsData?.libraryItems || []
 
   useEffect(() => {
     if (!libraryImportModalOpen) {
@@ -407,7 +410,7 @@ export const DataSetsPage: React.FC<DataSetsPageProps> = () => {
         }
       })
 
-      const data = (result.data as any)?.exportDataSets
+      const data = result.data?.exportDataSets
       if (data) {
         // Decode base64 to binary
         const binaryString = atob(data.fileContent)

--- a/frontend/src/components/editors/PlanVisualEditor/dialogs/DataSetDataDialog.tsx
+++ b/frontend/src/components/editors/PlanVisualEditor/dialogs/DataSetDataDialog.tsx
@@ -10,7 +10,7 @@ import { Spinner } from '@/components/ui/spinner';
 import { Stack } from '@/components/layout-primitives';
 import { IconAlertCircle } from '@tabler/icons-react';
 import { useQuery, useMutation } from '@apollo/client/react';
-import { GET_DATASOURCE, DataSet, UPDATE_DATASOURCE_GRAPH_DATA } from '../../../../graphql/datasets';
+import { GET_DATASOURCE, UPDATE_DATASOURCE_GRAPH_DATA } from '../../../../graphql/datasets';
 import { GraphSpreadsheetEditor, GraphData } from '../../../editors/GraphSpreadsheetEditor/GraphSpreadsheetEditor';
 import { sanitizeAttributes } from '@/utils/attributes';
 
@@ -27,8 +27,8 @@ export const DataSetDataDialog: React.FC<DataSetDataDialogProps> = ({
   dataSetId,
   title = 'Data Set Data'
 }) => {
-  const { data, loading, error, refetch } = useQuery<{ dataSet: DataSet }>(GET_DATASOURCE, {
-    variables: { id: dataSetId },
+  const { data, loading, error, refetch } = useQuery(GET_DATASOURCE, {
+    variables: { id: dataSetId ?? 0 },
     skip: !opened || !dataSetId,
     fetchPolicy: 'network-only'
   });

--- a/frontend/src/components/editors/PlanVisualEditor/dialogs/GraphDataDialog.tsx
+++ b/frontend/src/components/editors/PlanVisualEditor/dialogs/GraphDataDialog.tsx
@@ -12,7 +12,6 @@ import { IconAlertCircle } from '@tabler/icons-react';
 import { useQuery, useMutation } from '@apollo/client/react';
 import {
   GET_GRAPH_DETAILS,
-  Graph,
   BULK_UPDATE_GRAPH_DATA,
   ADD_GRAPH_NODE,
   ADD_GRAPH_EDGE,
@@ -35,8 +34,8 @@ export const GraphDataDialog: React.FC<GraphDataDialogProps> = ({
   graphId,
   title = 'Graph Data'
 }) => {
-  const { data, loading, error, refetch } = useQuery<{ graph: Graph }>(GET_GRAPH_DETAILS, {
-    variables: { id: graphId },
+  const { data, loading, error, refetch } = useQuery(GET_GRAPH_DETAILS, {
+    variables: { id: graphId ?? 0 },
     skip: !opened || !graphId,
     fetchPolicy: 'network-only'
   });

--- a/frontend/src/components/editors/PlanVisualEditor/forms/DataSetNodeConfigForm.tsx
+++ b/frontend/src/components/editors/PlanVisualEditor/forms/DataSetNodeConfigForm.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { IconAlertCircle, IconLoader2 } from '@tabler/icons-react';
 import { useQuery } from '@apollo/client/react';
-import { gql } from '@apollo/client';
+import { gql, type TypedDocumentNode } from '@apollo/client';
 import { DataSetNodeConfig, NodeMetadata } from '../../../../types/plan-dag';
 import { Stack } from '@/components/layout-primitives';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
@@ -9,7 +9,10 @@ import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 
 // GraphQL query for available data sets
-const GET_AVAILABLE_DATA_SETS = gql`
+const GET_AVAILABLE_DATA_SETS: TypedDocumentNode<
+  GetAvailableDataSetsData,
+  { projectId: number }
+> = gql`
   query GetAvailableDataSets($projectId: Int!) {
     dataSets(projectId: $projectId) {
       id
@@ -55,7 +58,7 @@ export const DataSetNodeConfigForm: React.FC<DataSetNodeConfigFormProps> = ({
   });
   const lastSentConfigRef = React.useRef<DataSetNodeConfig>(localConfig);
 
-  const { data, loading, error } = useQuery<GetAvailableDataSetsData>(GET_AVAILABLE_DATA_SETS, {
+  const { data, loading, error } = useQuery(GET_AVAILABLE_DATA_SETS, {
     variables: { projectId },
     skip: !projectId,
   });

--- a/frontend/src/components/editors/PlanVisualEditor/forms/ProjectionNodeConfigForm.tsx
+++ b/frontend/src/components/editors/PlanVisualEditor/forms/ProjectionNodeConfigForm.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
-import { gql } from '@apollo/client'
+import { gql, type TypedDocumentNode } from '@apollo/client'
 import { useLazyQuery, useMutation, useQuery } from '@apollo/client/react'
 import { ProjectionNodeConfig } from '../../../../types/plan-dag'
 import { Stack, Group } from '@/components/layout-primitives'
@@ -24,7 +24,23 @@ interface ProjectionNodeConfigFormProps {
   projectId: number
 }
 
-const PROJECTION_EDIT_QUERY = gql`
+const PROJECTION_EDIT_QUERY: TypedDocumentNode<
+  {
+    projection: {
+      id: string
+      name: string
+      projectionType: string
+      projectId: number
+      graphId: number
+    } | null
+    projectionState: {
+      projectionId: number
+      projectionType: string
+      stateJson: unknown
+    } | null
+  },
+  { id: string }
+> = gql`
   query ProjectionEdit($id: ID!) {
     projection(id: $id) {
       id
@@ -41,7 +57,16 @@ const PROJECTION_EDIT_QUERY = gql`
   }
 `
 
-const UPDATE_PROJECTION = gql`
+const UPDATE_PROJECTION: TypedDocumentNode<
+  {
+    updateProjection: {
+      id: string
+      name: string
+      projectionType: string
+    }
+  },
+  { id: string; input: Record<string, unknown> }
+> = gql`
   mutation UpdateProjection($id: ID!, $input: UpdateProjectionInput!) {
     updateProjection(id: $id, input: $input) {
       id
@@ -51,13 +76,31 @@ const UPDATE_PROJECTION = gql`
   }
 `
 
-const SAVE_PROJECTION_STATE = gql`
+const SAVE_PROJECTION_STATE: TypedDocumentNode<
+  { saveProjectionState: boolean },
+  { id: string; state: unknown }
+> = gql`
   mutation SaveProjectionState($id: ID!, $state: JSON!) {
     saveProjectionState(id: $id, state: $state)
   }
 `
 
-const VERIFY_PROJECTION_STORY_MATCH = gql`
+const VERIFY_PROJECTION_STORY_MATCH: TypedDocumentNode<
+  {
+    verifyProjectionStoryMatch: {
+      success: boolean
+      sequences: {
+        storyId: number
+        sequenceId: number
+        missingEdges: {
+          datasetId: number
+          edgeId: string
+        }[]
+      }[]
+    }
+  },
+  { projectionId: number; stories: Record<string, unknown>[] }
+> = gql`
   mutation VerifyProjectionStoryMatch($projectionId: Int!, $stories: [ProjectionStorySelectionInput!]!) {
     verifyProjectionStoryMatch(projectionId: $projectionId, stories: $stories) {
       success
@@ -79,7 +122,6 @@ type StorySelection = {
 }
 
 type SequenceInfo = { id: number; name: string }
-type SequencesQueryResult = { sequences: SequenceInfo[] }
 
 const buildSelectionPayload = (selections: Record<number, StorySelection>) =>
   Object.entries(selections)
@@ -134,7 +176,7 @@ export const ProjectionNodeConfigForm: React.FC<ProjectionNodeConfigFormProps> =
     skip: !projectId,
   })
 
-  const [loadSequences, { loading: loadingSeq }] = useLazyQuery<SequencesQueryResult, { storyId: number }>(
+  const [loadSequences, { loading: loadingSeq }] = useLazyQuery(
     LIST_SEQUENCES,
     {
       fetchPolicy: 'cache-first',
@@ -149,9 +191,9 @@ export const ProjectionNodeConfigForm: React.FC<ProjectionNodeConfigFormProps> =
   })
   const [verifyStories, { loading: verifying }] = useMutation(VERIFY_PROJECTION_STORY_MATCH)
 
-  const projection = (projectionData as any)?.projection
-  const projectionState = (projectionData as any)?.projectionState
-  const stories = (storiesData as any)?.stories ?? []
+  const projection = projectionData?.projection
+  const projectionState = projectionData?.projectionState
+  const stories = storiesData?.stories ?? []
 
   // Reset state when switching projections
   useEffect(() => {
@@ -315,12 +357,12 @@ export const ProjectionNodeConfigForm: React.FC<ProjectionNodeConfigFormProps> =
       const { data } = await verifyStories({
         variables: { projectionId: projectionId, stories: selection },
       })
-      const result = (data as any)?.verifyProjectionStoryMatch
+      const result = data?.verifyProjectionStoryMatch
       if (!result) {
         showErrorNotification('Verification failed', 'No result returned')
         return
       }
-      const missing = (result.sequences as any[]) ?? []
+      const missing = result.sequences ?? []
       setVerificationResult({ success: result.success, missing })
       if (result.success || missing.length === 0) {
         showSuccessNotification('Verified', 'All selected stories match this projection graph.')

--- a/frontend/src/components/editors/PlanVisualEditor/forms/SequenceArtefactNodeConfigForm.tsx
+++ b/frontend/src/components/editors/PlanVisualEditor/forms/SequenceArtefactNodeConfigForm.tsx
@@ -69,7 +69,7 @@ export const SequenceArtefactNodeConfigForm: React.FC<SequenceArtefactNodeConfig
 
   // Fetch sequences if we have a storyId (from connected StoryNode)
   const { data: sequencesData, loading: sequencesLoading } = useQuery(LIST_SEQUENCES, {
-    variables: { storyId },
+    variables: { storyId: storyId ?? 0 },
     skip: !storyId,
   });
   const sequences: Sequence[] = (sequencesData as any)?.sequences || [];

--- a/frontend/src/components/editors/PlanVisualEditor/nodes/GraphNode.tsx
+++ b/frontend/src/components/editors/PlanVisualEditor/nodes/GraphNode.tsx
@@ -63,9 +63,7 @@ export const GraphNode = memo((props: GraphNodeProps) => {
   const planId = data.planId as number | undefined
   const { updateNode } = usePlanDagCQRSMutations({ projectId: projectId || 0, planId: planId || 0 })
   const [updateGraphName] = useMutation(UPDATE_GRAPH)
-  const [validateGraphMutation, { loading: validatingGraph }] = useMutation<{
-    validateGraph: GraphValidationResult
-  }, { id: number }>(VALIDATE_GRAPH)
+  const [validateGraphMutation, { loading: validatingGraph }] = useMutation(VALIDATE_GRAPH)
 
   const config = data.config as GraphNodeConfig
 

--- a/frontend/src/components/editors/PlanVisualEditor/nodes/StoryNode.tsx
+++ b/frontend/src/components/editors/PlanVisualEditor/nodes/StoryNode.tsx
@@ -30,7 +30,7 @@ export const StoryNode = memo((props: ExtendedNodeProps) => {
 
   // Fetch story details if configured
   const { data: storyData, loading: storyLoading } = useQuery(GET_STORY, {
-    variables: { id: storyId },
+    variables: { id: storyId ?? 0 },
     skip: !storyId || storyId <= 0,
   })
 

--- a/frontend/src/components/graphs/GraphsPage.tsx
+++ b/frontend/src/components/graphs/GraphsPage.tsx
@@ -27,7 +27,7 @@ import { Input } from '../ui/input'
 import { Label } from '../ui/label'
 import { Spinner } from '../ui/spinner'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
-import { gql } from '@apollo/client'
+import { gql, type TypedDocumentNode } from '@apollo/client'
 import { Breadcrumbs } from '../common/Breadcrumbs'
 import { Graph, GET_GRAPHS, CREATE_GRAPH, UPDATE_GRAPH, DELETE_GRAPH, EXECUTE_NODE, GET_GRAPH_DETAILS } from '../../graphql/graphs'
 import { GET_PLAN_DAG, UPDATE_PLAN_DAG_NODE } from '../../graphql/plan-dag'
@@ -38,7 +38,10 @@ import { GraphPreviewDialog } from '../visualization'
 import type { GraphData } from '../visualization/GraphPreview'
 import { useProjectPlanSelection } from '../../hooks/useProjectPlanSelection'
 
-const GET_PROJECTS = gql`
+const GET_PROJECTS: TypedDocumentNode<
+  { projects: Array<{ id: number; name: string }> },
+  Record<string, never>
+> = gql`
   query GetProjects {
     projects {
       id
@@ -139,26 +142,15 @@ export const GraphsPage: React.FC<GraphsPageProps> = () => {
   } = useProjectPlanSelection(projectIdNum)
   const planQuerySuffix = selectedPlanId ? `?planId=${selectedPlanId}` : ''
 
-  const { data: projectsData } = useQuery<{ projects: Array<{ id: number; name: string }> }>(GET_PROJECTS)
-  const selectedProject = projectsData?.projects.find((p: { id: number; name: string }) => p.id === projectIdNum)
+  const { data: projectsData } = useQuery(GET_PROJECTS)
+  const selectedProject = projectsData?.projects.find((p) => p.id === projectIdNum)
 
-  const { data, loading: graphsLoading, error } = useQuery<{ graphs: Graph[] }>(GET_GRAPHS, {
+  const { data, loading: graphsLoading, error } = useQuery(GET_GRAPHS, {
     variables: { projectId: projectIdNum },
     fetchPolicy: 'cache-and-network'
   })
 
-  interface PlanDagNode {
-    id: string
-    nodeType: string
-  }
-
-  interface PlanDagResponse {
-    getPlanDag: {
-      nodes: PlanDagNode[]
-    }
-  }
-
-  const { data: planDagData, loading: planDagLoading } = useQuery<PlanDagResponse>(GET_PLAN_DAG, {
+  const { data: planDagData, loading: planDagLoading } = useQuery(GET_PLAN_DAG, {
     variables: { projectId: projectIdNum, planId: selectedPlanId },
     fetchPolicy: 'cache-and-network',
     skip: !selectedPlanId,
@@ -183,7 +175,7 @@ export const GraphsPage: React.FC<GraphsPageProps> = () => {
     refetchQueries: [{ query: GET_GRAPHS, variables: { projectId: projectIdNum } }]
   })
 
-  const { data: previewDetails, loading: previewLoading, error: previewError } = useQuery<{ graph: Graph }>(
+  const { data: previewDetails, loading: previewLoading, error: previewError } = useQuery(
     GET_GRAPH_DETAILS,
     {
       variables: { id: previewGraphId ?? 0 },

--- a/frontend/src/components/plans/PlansPage.tsx
+++ b/frontend/src/components/plans/PlansPage.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react'
 import { useMutation, useQuery } from '@apollo/client/react'
 import { useNavigate, useParams } from 'react-router-dom'
-import { gql } from '@apollo/client'
+import { gql, type TypedDocumentNode } from '@apollo/client'
 import { LIST_PLANS, DELETE_PLAN, DUPLICATE_PLAN } from '@/graphql/plans'
 import { Plan } from '@/types/plan'
 import { Breadcrumbs } from '@/components/common/Breadcrumbs'
@@ -17,7 +17,10 @@ import { CreatePlanModal } from './CreatePlanModal'
 import { EditPlanModal } from './EditPlanModal'
 import { showErrorNotification, showSuccessNotification } from '@/utils/notifications'
 
-const GET_PROJECT = gql`
+const GET_PROJECT: TypedDocumentNode<
+  { project: { id: number; name: string; description?: string | null } | null },
+  { id: number }
+> = gql`
   query GetProject($id: Int!) {
     project(id: $id) {
       id
@@ -43,7 +46,7 @@ export const PlansPage = () => {
   const [editModalOpen, setEditModalOpen] = useState(false)
   const [planToEdit, setPlanToEdit] = useState<Plan | null>(null)
 
-  const { data: projectData } = useQuery<{ project: { id: number; name: string; description?: string | null } }>(GET_PROJECT, {
+  const { data: projectData } = useQuery(GET_PROJECT, {
     variables: { id: projectIdNum },
     skip: !projectIdNum,
     fetchPolicy: 'cache-and-network',
@@ -54,7 +57,7 @@ export const PlansPage = () => {
     loading,
     error,
     refetch,
-  } = useQuery<{ plans: Plan[] }>(LIST_PLANS, {
+  } = useQuery(LIST_PLANS, {
     variables: { projectId: projectIdNum },
     skip: !projectIdNum,
     fetchPolicy: 'cache-and-network',

--- a/frontend/src/components/project/CreateProjectModal.tsx
+++ b/frontend/src/components/project/CreateProjectModal.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react'
 import { useMutation } from '@apollo/client/react'
-import { gql } from '@apollo/client'
+import { gql, type TypedDocumentNode } from '@apollo/client'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import * as z from 'zod'
@@ -27,7 +27,19 @@ import { Stack } from '@/components/layout-primitives'
 import { showErrorNotification } from '@/utils/notifications'
 import { UPDATE_PLAN_DAG } from '../../graphql/plan-dag'
 
-const CREATE_PROJECT = gql`
+const CREATE_PROJECT: TypedDocumentNode<
+  {
+    createProject: {
+      id: number
+      name: string
+      description?: string
+      tags?: string[]
+      createdAt: string
+      updatedAt: string
+    }
+  },
+  { input: Record<string, unknown> }
+> = gql`
   mutation CreateProject($input: CreateProjectInput!) {
     createProject(input: $input) {
       id
@@ -80,26 +92,12 @@ export const CreateProjectModal: React.FC<CreateProjectModalProps> = ({
   onSuccess,
   defaultTags = []
 }) => {
-  const [createProject, { loading }] = useMutation<{
-    createProject: {
-      id: number
-      name: string
-      description?: string
-      createdAt: string
-      updatedAt: string
-    }
-  }>(CREATE_PROJECT, {
+  const [createProject, { loading }] = useMutation(CREATE_PROJECT, {
     refetchQueries: [{ query: GET_PROJECTS }],
     awaitRefetchQueries: true
   })
 
-  const [initializePlanDag] = useMutation<{
-    updatePlanDag: {
-      success: boolean
-      errors: string[]
-      planDag: any
-    }
-  }>(UPDATE_PLAN_DAG)
+  const [initializePlanDag] = useMutation(UPDATE_PLAN_DAG)
 
   const form = useForm<CreateProjectFormValues>({
     resolver: zodResolver(createProjectSchema),

--- a/frontend/src/graphql/client.ts
+++ b/frontend/src/graphql/client.ts
@@ -9,6 +9,26 @@ import { getOrCreateSessionId } from '../utils/session'
 import { extractGraphQLErrorMessage } from '../utils/errorHandling'
 import { showErrorNotification } from '../utils/notifications'
 
+// Apollo Client 4.2+ requires any non-default `errorPolicy` used in
+// `defaultOptions` to be declared here for type safety. We default to
+// `errorPolicy: 'all'` (below) so partial data still renders when a request
+// also returns errors — declare that on each operation kind.
+declare module '@apollo/client' {
+  namespace ApolloClient {
+    namespace DeclareDefaultOptions {
+      interface WatchQuery {
+        errorPolicy: 'all'
+      }
+      interface Query {
+        errorPolicy: 'all'
+      }
+      interface Mutate {
+        errorPolicy: 'all'
+      }
+    }
+  }
+}
+
 export type GraphQLEndpointOverride = {
   httpPath?: string;
   wsPath?: string;

--- a/frontend/src/graphql/datasets.ts
+++ b/frontend/src/graphql/datasets.ts
@@ -1,7 +1,10 @@
-import { gql } from '@apollo/client'
+import { gql, type TypedDocumentNode } from '@apollo/client'
 
 // Query to fetch all DataSets for a project
-export const GET_DATASOURCES = gql`
+export const GET_DATASOURCES: TypedDocumentNode<
+  { dataSets: DataSet[] },
+  { projectId: number }
+> = gql`
   query GetDataSets($projectId: Int!) {
     dataSets(projectId: $projectId) {
       id
@@ -32,7 +35,10 @@ export const GET_DATASOURCES = gql`
 `
 
 // Query to fetch a single DataSet by ID
-export const GET_DATASOURCE = gql`
+export const GET_DATASOURCE: TypedDocumentNode<
+  { dataSet: DataSet | null },
+  { id: number }
+> = gql`
   query GetDataSet($id: Int!) {
     dataSet(id: $id) {
       id
@@ -63,7 +69,10 @@ export const GET_DATASOURCE = gql`
 `
 
 // Mutation to create a new DataSet from uploaded file
-export const CREATE_DATASOURCE_FROM_FILE = gql`
+export const CREATE_DATASOURCE_FROM_FILE: TypedDocumentNode<
+  { createDataSetFromFile: DataSet },
+  { input: CreateDataSetInput }
+> = gql`
   mutation CreateDataSetFromFile($input: CreateDataSetInput!) {
     createDataSetFromFile(input: $input) {
       id
@@ -94,7 +103,10 @@ export const CREATE_DATASOURCE_FROM_FILE = gql`
 `
 
 // Mutation to create a new empty DataSet (without file upload)
-export const CREATE_EMPTY_DATASOURCE = gql`
+export const CREATE_EMPTY_DATASOURCE: TypedDocumentNode<
+  { createEmptyDataSet: DataSet },
+  { input: CreateEmptyDataSetInput }
+> = gql`
   mutation CreateEmptyDataSet($input: CreateEmptyDataSetInput!) {
     createEmptyDataSet(input: $input) {
       id
@@ -120,7 +132,10 @@ export const CREATE_EMPTY_DATASOURCE = gql`
 `
 
 // Mutation to bulk upload multiple DataSets with auto-detection
-export const BULK_UPLOAD_DATASOURCES = gql`
+export const BULK_UPLOAD_DATASOURCES: TypedDocumentNode<
+  { bulkUploadDataSets: DataSet[] },
+  { projectId: number; files: BulkUploadDataSetInput[] }
+> = gql`
   mutation BulkUploadDataSets($projectId: Int!, $files: [BulkUploadDataSetInput!]!) {
     bulkUploadDataSets(projectId: $projectId, files: $files) {
       id
@@ -146,7 +161,10 @@ export const BULK_UPLOAD_DATASOURCES = gql`
 `
 
 // Mutation to update DataSet metadata
-export const UPDATE_DATASOURCE = gql`
+export const UPDATE_DATASOURCE: TypedDocumentNode<
+  { updateDataSet: DataSet },
+  { id: number; input: UpdateDataSetInput }
+> = gql`
   mutation UpdateDataSet($id: Int!, $input: UpdateDataSetInput!) {
     updateDataSet(id: $id, input: $input) {
       id
@@ -171,7 +189,10 @@ export const UPDATE_DATASOURCE = gql`
   }
 `
 
-export const VALIDATE_DATASET = gql`
+export const VALIDATE_DATASET: TypedDocumentNode<
+  { validateDataSet: DataSetValidationResult },
+  { id: number }
+> = gql`
   mutation ValidateDataSet($id: Int!) {
     validateDataSet(id: $id) {
       dataSetId
@@ -188,14 +209,20 @@ export const VALIDATE_DATASET = gql`
 `
 
 // Mutation to delete a DataSet
-export const DELETE_DATASOURCE = gql`
+export const DELETE_DATASOURCE: TypedDocumentNode<
+  { deleteDataSet: boolean },
+  { id: number }
+> = gql`
   mutation DeleteDataSet($id: Int!) {
     deleteDataSet(id: $id)
   }
 `
 
 // Mutation to reprocess an existing DataSet
-export const REPROCESS_DATASOURCE = gql`
+export const REPROCESS_DATASOURCE: TypedDocumentNode<
+  { reprocessDataSet: DataSet },
+  { id: number }
+> = gql`
   mutation ReprocessDataSet($id: Int!) {
     reprocessDataSet(id: $id) {
       id
@@ -221,7 +248,10 @@ export const REPROCESS_DATASOURCE = gql`
 `
 
 // Mutation to update graph JSON data
-export const UPDATE_DATASOURCE_GRAPH_DATA = gql`
+export const UPDATE_DATASOURCE_GRAPH_DATA: TypedDocumentNode<
+  { updateDataSetGraphData: DataSet },
+  { id: number; graphJson: string }
+> = gql`
   mutation UpdateDataSetGraphData($id: Int!, $graphJson: String!) {
     updateDataSetGraphData(id: $id, graphJson: $graphJson) {
       id
@@ -247,7 +277,10 @@ export const UPDATE_DATASOURCE_GRAPH_DATA = gql`
 `
 
 // Subscription for DataSet updates
-export const DATASOURCE_UPDATED = gql`
+export const DATASOURCE_UPDATED: TypedDocumentNode<
+  { dataSetUpdated: DataSet },
+  { projectId: number }
+> = gql`
   subscription DataSetUpdated($projectId: Int!) {
     dataSetUpdated(projectId: $projectId) {
       id
@@ -273,7 +306,10 @@ export const DATASOURCE_UPDATED = gql`
 `
 
 // Export data sources as spreadsheet
-export const EXPORT_DATASOURCES = gql`
+export const EXPORT_DATASOURCES: TypedDocumentNode<
+  { exportDataSets: { fileContent: string; filename: string; format: string } },
+  { input: Record<string, unknown> }
+> = gql`
   mutation ExportDataSets($input: ExportDataSetsInput!) {
     exportDataSets(input: $input) {
       fileContent
@@ -284,7 +320,10 @@ export const EXPORT_DATASOURCES = gql`
 `
 
 // Import data sources from spreadsheet
-export const IMPORT_DATASOURCES = gql`
+export const IMPORT_DATASOURCES: TypedDocumentNode<
+  { importDataSets: { dataSets: DataSet[]; createdCount: number; updatedCount: number } },
+  { input: Record<string, unknown> }
+> = gql`
   mutation ImportDataSets($input: ImportDataSetsInput!) {
     importDataSets(input: $input) {
       dataSets {
@@ -313,7 +352,10 @@ export const IMPORT_DATASOURCES = gql`
 `
 
 // Merge multiple data sets into a single new data set
-export const MERGE_DATASOURCES = gql`
+export const MERGE_DATASOURCES: TypedDocumentNode<
+  { mergeDataSets: DataSet },
+  { input: Record<string, unknown> }
+> = gql`
   mutation MergeDataSets($input: MergeDataSetsInput!) {
     mergeDataSets(input: $input) {
       id
@@ -377,7 +419,10 @@ export interface DataSet {
   hasLayers?: boolean
 }
 
-export const GET_GRAPH_SUMMARY = gql`
+export const GET_GRAPH_SUMMARY: TypedDocumentNode<
+  { graphSummary: GraphSummary },
+  { datasetId: number }
+> = gql`
   query GraphSummary($datasetId: Int!) {
     graphSummary(datasetId: $datasetId) {
       nodeCount
@@ -388,7 +433,10 @@ export const GET_GRAPH_SUMMARY = gql`
   }
 `
 
-export const GET_GRAPH_PAGE = gql`
+export const GET_GRAPH_PAGE: TypedDocumentNode<
+  { graphPage: GraphPageSlice },
+  { datasetId: number; limit: number; offset: number; layers?: string[] | null }
+> = gql`
   query GraphPage($datasetId: Int!, $limit: Int!, $offset: Int!, $layers: [String!]) {
     graphPage(datasetId: $datasetId, limit: $limit, offset: $offset, layers: $layers) {
       hasMore

--- a/frontend/src/graphql/export.ts
+++ b/frontend/src/graphql/export.ts
@@ -1,6 +1,14 @@
-import { gql } from '@apollo/client'
+import { gql, type TypedDocumentNode } from '@apollo/client'
 
-export const EXPORT_NODE_OUTPUT = gql`
+export const EXPORT_NODE_OUTPUT: TypedDocumentNode<
+  { exportNodeOutput: ExportNodeOutputResult },
+  {
+    projectId: number
+    nodeId: string
+    planId?: number | null
+    renderConfig?: Record<string, unknown> | null
+  }
+> = gql`
   mutation ExportNodeOutput(
     $projectId: Int!
     $nodeId: String!

--- a/frontend/src/graphql/graphs.ts
+++ b/frontend/src/graphql/graphs.ts
@@ -1,4 +1,4 @@
-import { gql } from '@apollo/client'
+import { gql, type TypedDocumentNode } from '@apollo/client'
 import { AttributesMap } from '@/utils/attributes'
 
 export interface Layer {
@@ -98,7 +98,10 @@ export interface ReplaySummary {
   details: EditResult[]
 }
 
-export const GET_GRAPHS = gql`
+export const GET_GRAPHS: TypedDocumentNode<
+  { graphs: Graph[] },
+  { projectId: number }
+> = gql`
   query GetGraphs($projectId: Int!) {
     graphs(projectId: $projectId) {
       id
@@ -126,7 +129,10 @@ export const GET_GRAPHS = gql`
   }
 `
 
-export const GET_GRAPH_DETAILS = gql`
+export const GET_GRAPH_DETAILS: TypedDocumentNode<
+  { graph: Graph | null },
+  { id: number }
+> = gql`
   query GetGraphDetails($id: Int!) {
     graph(id: $id) {
       id
@@ -174,7 +180,10 @@ export const GET_GRAPH_DETAILS = gql`
   }
 `
 
-export const CREATE_GRAPH = gql`
+export const CREATE_GRAPH: TypedDocumentNode<
+  { createGraph: { id: number } },
+  { input: Record<string, unknown> }
+> = gql`
   mutation CreateGraph($input: CreateGraphInput!) {
     createGraph(input: $input) {
       id
@@ -182,7 +191,10 @@ export const CREATE_GRAPH = gql`
   }
 `
 
-export const UPDATE_GRAPH = gql`
+export const UPDATE_GRAPH: TypedDocumentNode<
+  { updateGraph: { id: number } },
+  { id: number; input: Record<string, unknown> }
+> = gql`
   mutation UpdateGraph($id: Int!, $input: UpdateGraphInput!) {
     updateGraph(id: $id, input: $input) {
       id
@@ -190,13 +202,19 @@ export const UPDATE_GRAPH = gql`
   }
 `
 
-export const DELETE_GRAPH = gql`
+export const DELETE_GRAPH: TypedDocumentNode<
+  { deleteGraph: boolean },
+  { id: number }
+> = gql`
   mutation DeleteGraph($id: Int!) {
     deleteGraph(id: $id)
   }
 `
 
-export const EXECUTE_NODE = gql`
+export const EXECUTE_NODE: TypedDocumentNode<
+  { executeNode: { success: boolean; message: string; nodeId: string } },
+  { projectId: number; nodeId: string }
+> = gql`
   mutation ExecuteNode($projectId: Int!, $nodeId: String!) {
     executeNode(projectId: $projectId, nodeId: $nodeId) {
       success
@@ -206,7 +224,10 @@ export const EXECUTE_NODE = gql`
   }
 `
 
-export const VALIDATE_GRAPH = gql`
+export const VALIDATE_GRAPH: TypedDocumentNode<
+  { validateGraph: GraphValidationResult },
+  { id: number }
+> = gql`
   mutation ValidateGraph($id: Int!) {
     validateGraph(id: $id) {
       graphId
@@ -222,7 +243,25 @@ export const VALIDATE_GRAPH = gql`
   }
 `
 
-export const UPDATE_GRAPH_NODE = gql`
+export const UPDATE_GRAPH_NODE: TypedDocumentNode<
+  {
+    updateGraphNode: {
+      id: string
+      label?: string
+      layer?: string
+      attributes?: AttributesMap
+      belongsTo?: string
+    }
+  },
+  {
+    graphId: number
+    nodeId: string
+    label?: string
+    layer?: string
+    attributes?: unknown
+    belongsTo?: string
+  }
+> = gql`
   mutation UpdateGraphNode(
     $graphId: Int!
     $nodeId: String!
@@ -248,7 +287,29 @@ export const UPDATE_GRAPH_NODE = gql`
   }
 `
 
-export const ADD_GRAPH_NODE = gql`
+export const ADD_GRAPH_NODE: TypedDocumentNode<
+  {
+    addGraphNode: {
+      id: string
+      label?: string
+      layer?: string
+      isPartition: boolean
+      belongsTo?: string
+      weight?: number
+      attributes?: AttributesMap
+    }
+  },
+  {
+    graphId: number
+    id: string
+    label?: string
+    layer?: string
+    isPartition: boolean
+    belongsTo?: string
+    weight?: number
+    attributes?: unknown
+  }
+> = gql`
   mutation AddGraphNode(
     $graphId: Int!
     $id: String!
@@ -280,7 +341,29 @@ export const ADD_GRAPH_NODE = gql`
   }
 `
 
-export const ADD_GRAPH_EDGE = gql`
+export const ADD_GRAPH_EDGE: TypedDocumentNode<
+  {
+    addGraphEdge: {
+      id: string
+      source: string
+      target: string
+      label?: string
+      layer?: string
+      weight?: number
+      attributes?: AttributesMap
+    }
+  },
+  {
+    graphId: number
+    id: string
+    source: string
+    target: string
+    label?: string
+    layer?: string
+    weight?: number
+    attributes?: unknown
+  }
+> = gql`
   mutation AddGraphEdge(
     $graphId: Int!
     $id: String!
@@ -312,7 +395,25 @@ export const ADD_GRAPH_EDGE = gql`
   }
 `
 
-export const UPDATE_GRAPH_EDGE = gql`
+export const UPDATE_GRAPH_EDGE: TypedDocumentNode<
+  {
+    updateGraphEdge: {
+      id: string
+      source: string
+      target: string
+      label?: string
+      layer?: string
+      attributes?: AttributesMap
+    }
+  },
+  {
+    graphId: number
+    edgeId: string
+    label?: string
+    layer?: string
+    attributes?: unknown
+  }
+> = gql`
   mutation UpdateGraphEdge(
     $graphId: Int!
     $edgeId: String!
@@ -337,19 +438,28 @@ export const UPDATE_GRAPH_EDGE = gql`
   }
 `
 
-export const DELETE_GRAPH_EDGE = gql`
+export const DELETE_GRAPH_EDGE: TypedDocumentNode<
+  { deleteGraphEdge: boolean },
+  { graphId: number; edgeId: string }
+> = gql`
   mutation DeleteGraphEdge($graphId: Int!, $edgeId: String!) {
     deleteGraphEdge(graphId: $graphId, edgeId: $edgeId)
   }
 `
 
-export const DELETE_GRAPH_NODE = gql`
+export const DELETE_GRAPH_NODE: TypedDocumentNode<
+  { deleteGraphNode: boolean },
+  { graphId: number; nodeId: string }
+> = gql`
   mutation DeleteGraphNode($graphId: Int!, $nodeId: String!) {
     deleteGraphNode(graphId: $graphId, nodeId: $nodeId)
   }
 `
 
-export const BULK_UPDATE_GRAPH_DATA = gql`
+export const BULK_UPDATE_GRAPH_DATA: TypedDocumentNode<
+  { bulkUpdateGraphData: boolean },
+  { graphId: number; nodes?: Record<string, unknown>[] }
+> = gql`
   mutation BulkUpdateGraphData(
     $graphId: Int!
     $nodes: [GraphNodeUpdateInput!]
@@ -361,7 +471,10 @@ export const BULK_UPDATE_GRAPH_DATA = gql`
   }
 `
 
-export const GET_GRAPH_EDITS = gql`
+export const GET_GRAPH_EDITS: TypedDocumentNode<
+  { graphEdits: GraphEdit[] },
+  { graphId: number; unappliedOnly?: boolean }
+> = gql`
   query GetGraphEdits($graphId: Int!, $unappliedOnly: Boolean) {
     graphEdits(graphId: $graphId, unappliedOnly: $unappliedOnly) {
       id
@@ -380,13 +493,19 @@ export const GET_GRAPH_EDITS = gql`
   }
 `
 
-export const GET_GRAPH_EDIT_COUNT = gql`
+export const GET_GRAPH_EDIT_COUNT: TypedDocumentNode<
+  { graphEditCount: number },
+  { graphId: number; unappliedOnly?: boolean }
+> = gql`
   query GetGraphEditCount($graphId: Int!, $unappliedOnly: Boolean) {
     graphEditCount(graphId: $graphId, unappliedOnly: $unappliedOnly)
   }
 `
 
-export const REPLAY_GRAPH_EDITS = gql`
+export const REPLAY_GRAPH_EDITS: TypedDocumentNode<
+  { replayGraphEdits: ReplaySummary },
+  { graphId: number }
+> = gql`
   mutation ReplayGraphEdits($graphId: Int!) {
     replayGraphEdits(graphId: $graphId) {
       total
@@ -405,7 +524,10 @@ export const REPLAY_GRAPH_EDITS = gql`
   }
 `
 
-export const CLEAR_GRAPH_EDITS = gql`
+export const CLEAR_GRAPH_EDITS: TypedDocumentNode<
+  { clearGraphEdits: boolean },
+  { graphId: number }
+> = gql`
   mutation ClearGraphEdits($graphId: Int!) {
     clearGraphEdits(graphId: $graphId)
   }

--- a/frontend/src/graphql/layers.ts
+++ b/frontend/src/graphql/layers.ts
@@ -1,6 +1,9 @@
-import { gql } from '@apollo/client'
+import { gql, type TypedDocumentNode } from '@apollo/client'
 
-export const GET_PROJECT_LAYERS = gql`
+export const GET_PROJECT_LAYERS: TypedDocumentNode<
+  { projectLayers: ProjectLayer[]; missingLayers: string[] },
+  { projectId: number }
+> = gql`
   query GetProjectLayers($projectId: Int!) {
     projectLayers(projectId: $projectId) {
       id
@@ -25,7 +28,10 @@ export const GET_PROJECT_LAYERS = gql`
   }
 `
 
-export const UPSERT_PROJECT_LAYER = gql`
+export const UPSERT_PROJECT_LAYER: TypedDocumentNode<
+  { upsertProjectLayer: ProjectLayer },
+  { projectId: number; input: ProjectLayerInput }
+> = gql`
   mutation UpsertProjectLayer($projectId: Int!, $input: ProjectLayerInput!) {
     upsertProjectLayer(projectId: $projectId, input: $input) {
       id
@@ -42,7 +48,10 @@ export const UPSERT_PROJECT_LAYER = gql`
   }
 `
 
-export const DELETE_PROJECT_LAYER = gql`
+export const DELETE_PROJECT_LAYER: TypedDocumentNode<
+  { deleteProjectLayer: boolean },
+  { projectId: number; layerId: string; sourceDatasetId?: number | null }
+> = gql`
   mutation DeleteProjectLayer($projectId: Int!, $layerId: String!, $sourceDatasetId: Int) {
     deleteProjectLayer(
       projectId: $projectId
@@ -52,19 +61,28 @@ export const DELETE_PROJECT_LAYER = gql`
   }
 `
 
-export const SET_LAYER_DATASET_ENABLED = gql`
+export const SET_LAYER_DATASET_ENABLED: TypedDocumentNode<
+  { setLayerDatasetEnabled: boolean },
+  { projectId: number; dataSetId: number; enabled: boolean }
+> = gql`
   mutation SetLayerDatasetEnabled($projectId: Int!, $dataSetId: Int!, $enabled: Boolean!) {
     setLayerDatasetEnabled(projectId: $projectId, dataSetId: $dataSetId, enabled: $enabled)
   }
 `
 
-export const RESET_PROJECT_LAYERS = gql`
+export const RESET_PROJECT_LAYERS: TypedDocumentNode<
+  { resetProjectLayers: boolean },
+  { projectId: number }
+> = gql`
   mutation ResetProjectLayers($projectId: Int!) {
     resetProjectLayers(projectId: $projectId)
   }
 `
 
-export const LIST_LAYER_ALIASES = gql`
+export const LIST_LAYER_ALIASES: TypedDocumentNode<
+  { listLayerAliases: LayerAlias[] },
+  { projectId: number }
+> = gql`
   query ListLayerAliases($projectId: Int!) {
     listLayerAliases(projectId: $projectId) {
       id
@@ -84,7 +102,10 @@ export const LIST_LAYER_ALIASES = gql`
   }
 `
 
-export const GET_LAYER_ALIASES = gql`
+export const GET_LAYER_ALIASES: TypedDocumentNode<
+  { getLayerAliases: LayerAlias[] },
+  { projectId: number; targetLayerId: number }
+> = gql`
   query GetLayerAliases($projectId: Int!, $targetLayerId: Int!) {
     getLayerAliases(projectId: $projectId, targetLayerId: $targetLayerId) {
       id
@@ -96,7 +117,10 @@ export const GET_LAYER_ALIASES = gql`
   }
 `
 
-export const CREATE_LAYER_ALIAS = gql`
+export const CREATE_LAYER_ALIAS: TypedDocumentNode<
+  { createLayerAlias: LayerAlias },
+  { projectId: number; aliasLayerId: string; targetLayerId: number }
+> = gql`
   mutation CreateLayerAlias($projectId: Int!, $aliasLayerId: String!, $targetLayerId: Int!) {
     createLayerAlias(
       projectId: $projectId
@@ -117,13 +141,19 @@ export const CREATE_LAYER_ALIAS = gql`
   }
 `
 
-export const REMOVE_LAYER_ALIAS = gql`
+export const REMOVE_LAYER_ALIAS: TypedDocumentNode<
+  { removeLayerAlias: boolean },
+  { projectId: number; aliasLayerId: string }
+> = gql`
   mutation RemoveLayerAlias($projectId: Int!, $aliasLayerId: String!) {
     removeLayerAlias(projectId: $projectId, aliasLayerId: $aliasLayerId)
   }
 `
 
-export const REMOVE_LAYER_ALIASES = gql`
+export const REMOVE_LAYER_ALIASES: TypedDocumentNode<
+  { removeLayerAliases: boolean },
+  { projectId: number; targetLayerId: number }
+> = gql`
   mutation RemoveLayerAliases($projectId: Int!, $targetLayerId: Int!) {
     removeLayerAliases(projectId: $projectId, targetLayerId: $targetLayerId)
   }

--- a/frontend/src/graphql/libraryItems.ts
+++ b/frontend/src/graphql/libraryItems.ts
@@ -1,7 +1,10 @@
-import { gql } from '@apollo/client'
-import { FileFormat, DataType, formatFileSize, getFileFormatDisplayName, getDataTypeDisplayName, detectFileFormat } from './datasets'
+import { gql, type TypedDocumentNode } from '@apollo/client'
+import { FileFormat, DataType, formatFileSize, getFileFormatDisplayName, getDataTypeDisplayName, detectFileFormat, type DataSet } from './datasets'
 
-export const GET_LIBRARY_ITEMS = gql`
+export const GET_LIBRARY_ITEMS: TypedDocumentNode<
+  { libraryItems: LibraryItem[] },
+  { filter?: Record<string, unknown> }
+> = gql`
   query GetLibraryItems($filter: LibraryItemFilterInput) {
     libraryItems(filter: $filter) {
       id
@@ -17,7 +20,10 @@ export const GET_LIBRARY_ITEMS = gql`
   }
 `
 
-export const UPLOAD_LIBRARY_ITEM = gql`
+export const UPLOAD_LIBRARY_ITEM: TypedDocumentNode<
+  { uploadLibraryItem: LibraryItem },
+  { input: UploadLibraryItemInput }
+> = gql`
   mutation UploadLibraryItem($input: UploadLibraryItemInput!) {
     uploadLibraryItem(input: $input) {
       id
@@ -33,13 +39,19 @@ export const UPLOAD_LIBRARY_ITEM = gql`
   }
 `
 
-export const DELETE_LIBRARY_ITEM = gql`
+export const DELETE_LIBRARY_ITEM: TypedDocumentNode<
+  { deleteLibraryItem: boolean },
+  { id: number }
+> = gql`
   mutation DeleteLibraryItem($id: Int!) {
     deleteLibraryItem(id: $id)
   }
 `
 
-export const UPDATE_LIBRARY_ITEM = gql`
+export const UPDATE_LIBRARY_ITEM: TypedDocumentNode<
+  { updateLibraryItem: LibraryItem },
+  { id: number; input: Record<string, unknown> }
+> = gql`
   mutation UpdateLibraryItem($id: Int!, $input: UpdateLibraryItemInput!) {
     updateLibraryItem(id: $id, input: $input) {
       id
@@ -52,7 +64,10 @@ export const UPDATE_LIBRARY_ITEM = gql`
   }
 `
 
-export const REDETECT_LIBRARY_DATASET_TYPE = gql`
+export const REDETECT_LIBRARY_DATASET_TYPE: TypedDocumentNode<
+  { redetectLibraryDatasetType: LibraryItem },
+  { id: number }
+> = gql`
   mutation RedetectLibraryDatasetType($id: Int!) {
     redetectLibraryDatasetType(id: $id) {
       id
@@ -66,7 +81,10 @@ export const REDETECT_LIBRARY_DATASET_TYPE = gql`
   }
 `
 
-export const IMPORT_LIBRARY_DATASETS = gql`
+export const IMPORT_LIBRARY_DATASETS: TypedDocumentNode<
+  { importLibraryDatasets: DataSet[] },
+  { input: ImportLibraryDatasetsInput }
+> = gql`
   mutation ImportLibraryDatasets($input: ImportLibraryDatasetsInput!) {
     importLibraryDatasets(input: $input) {
       id
@@ -87,7 +105,10 @@ export const IMPORT_LIBRARY_DATASETS = gql`
   }
 `
 
-export const SEED_LIBRARY_ITEMS = gql`
+export const SEED_LIBRARY_ITEMS: TypedDocumentNode<
+  { seedLibraryItems: SeedLibraryItemsResult },
+  Record<string, never>
+> = gql`
   mutation SeedLibraryItems {
     seedLibraryItems {
       totalRemoteFiles
@@ -98,7 +119,10 @@ export const SEED_LIBRARY_ITEMS = gql`
   }
 `
 
-export const EXPORT_PROJECT_AS_TEMPLATE = gql`
+export const EXPORT_PROJECT_AS_TEMPLATE: TypedDocumentNode<
+  { exportProjectAsTemplate: LibraryItem },
+  { projectId: number }
+> = gql`
   mutation ExportProjectAsTemplate($projectId: Int!) {
     exportProjectAsTemplate(projectId: $projectId) {
       id
@@ -114,7 +138,10 @@ export const EXPORT_PROJECT_AS_TEMPLATE = gql`
   }
 `
 
-export const EXPORT_PROJECT_ARCHIVE = gql`
+export const EXPORT_PROJECT_ARCHIVE: TypedDocumentNode<
+  { exportProjectArchive: ExportProjectArchivePayload },
+  { projectId: number }
+> = gql`
   mutation ExportProjectArchive($projectId: Int!) {
     exportProjectArchive(projectId: $projectId) {
       filename
@@ -123,7 +150,19 @@ export const EXPORT_PROJECT_ARCHIVE = gql`
   }
 `
 
-export const RESET_PROJECT = gql`
+export const RESET_PROJECT: TypedDocumentNode<
+  {
+    resetProject: {
+      id: number
+      name: string
+      description?: string
+      tags: string[]
+      createdAt: string
+      updatedAt: string
+    }
+  },
+  { projectId: number }
+> = gql`
   mutation ResetProject($projectId: Int!) {
     resetProject(projectId: $projectId) {
       id
@@ -136,7 +175,19 @@ export const RESET_PROJECT = gql`
   }
 `
 
-export const CREATE_PROJECT_FROM_LIBRARY = gql`
+export const CREATE_PROJECT_FROM_LIBRARY: TypedDocumentNode<
+  {
+    createProjectFromLibrary: {
+      id: number
+      name: string
+      description?: string
+      tags: string[]
+      createdAt: string
+      updatedAt: string
+    }
+  },
+  { libraryItemId: number; name?: string }
+> = gql`
   mutation CreateProjectFromLibrary($libraryItemId: Int!, $name: String) {
     createProjectFromLibrary(libraryItemId: $libraryItemId, name: $name) {
       id

--- a/frontend/src/graphql/plan-dag.ts
+++ b/frontend/src/graphql/plan-dag.ts
@@ -1,7 +1,11 @@
-import { gql } from '@apollo/client'
+import { gql, type TypedDocumentNode } from '@apollo/client'
+import type { PlanDag, PlanDagNode, PlanDagEdge } from '../types/plan-dag'
 
 // Plan DAG Queries
-export const GET_PLAN_DAG = gql`
+export const GET_PLAN_DAG: TypedDocumentNode<
+  { getPlanDag: PlanDag | null },
+  { projectId: number; planId?: number | null }
+> = gql`
   query GetPlanDag($projectId: Int!, $planId: Int) {
     getPlanDag(projectId: $projectId, planId: $planId) {
       version
@@ -58,7 +62,26 @@ export const GET_PLAN_DAG = gql`
   }
 `
 
-export const VALIDATE_PLAN_DAG = gql`
+export const VALIDATE_PLAN_DAG: TypedDocumentNode<
+  {
+    validatePlanDag: {
+      isValid: boolean
+      errors: Array<{
+        nodeId?: string | null
+        edgeId?: string | null
+        nodeType?: string | null
+        message: string
+      }>
+      warnings: Array<{
+        nodeId?: string | null
+        edgeId?: string | null
+        nodeType?: string | null
+        message: string
+      }>
+    }
+  },
+  { planDag: unknown }
+> = gql`
   query ValidatePlanDag($planDag: PlanDagInput!) {
     validatePlanDag(planDag: $planDag) {
       isValid
@@ -79,7 +102,10 @@ export const VALIDATE_PLAN_DAG = gql`
 `
 
 // Plan DAG Mutations
-export const UPDATE_PLAN_DAG = gql`
+export const UPDATE_PLAN_DAG: TypedDocumentNode<
+  { updatePlanDag: PlanDag },
+  { projectId: number; planId?: number | null; planDag: unknown }
+> = gql`
   mutation UpdatePlanDag($projectId: Int!, $planId: Int, $planDag: PlanDagInput!) {
     updatePlanDag(projectId: $projectId, planId: $planId, planDag: $planDag) {
       version
@@ -119,7 +145,10 @@ export const UPDATE_PLAN_DAG = gql`
   }
 `
 
-export const ADD_PLAN_DAG_NODE = gql`
+export const ADD_PLAN_DAG_NODE: TypedDocumentNode<
+  { addPlanDagNode: PlanDagNode },
+  { projectId: number; planId?: number | null; node: unknown }
+> = gql`
   mutation AddPlanDagNode($projectId: Int!, $planId: Int, $node: PlanDagNodeInput!) {
     addPlanDagNode(projectId: $projectId, planId: $planId, node: $node) {
       id
@@ -137,7 +166,15 @@ export const ADD_PLAN_DAG_NODE = gql`
   }
 `
 
-export const UPDATE_PLAN_DAG_NODE = gql`
+export const UPDATE_PLAN_DAG_NODE: TypedDocumentNode<
+  { updatePlanDagNode: PlanDagNode },
+  {
+    projectId: number
+    planId?: number | null
+    nodeId: string
+    updates: unknown
+  }
+> = gql`
   mutation UpdatePlanDagNode($projectId: Int!, $planId: Int, $nodeId: String!, $updates: PlanDagNodeUpdateInput!) {
     updatePlanDagNode(projectId: $projectId, planId: $planId, nodeId: $nodeId, updates: $updates) {
       id
@@ -155,7 +192,10 @@ export const UPDATE_PLAN_DAG_NODE = gql`
   }
 `
 
-export const DELETE_PLAN_DAG_NODE = gql`
+export const DELETE_PLAN_DAG_NODE: TypedDocumentNode<
+  { deletePlanDagNode: { id: string } },
+  { projectId: number; planId?: number | null; nodeId: string }
+> = gql`
   mutation DeletePlanDagNode($projectId: Int!, $planId: Int, $nodeId: String!) {
     deletePlanDagNode(projectId: $projectId, planId: $planId, nodeId: $nodeId) {
       id
@@ -163,7 +203,10 @@ export const DELETE_PLAN_DAG_NODE = gql`
   }
 `
 
-export const ADD_PLAN_DAG_EDGE = gql`
+export const ADD_PLAN_DAG_EDGE: TypedDocumentNode<
+  { addPlanDagEdge: PlanDagEdge },
+  { projectId: number; planId?: number | null; edge: unknown }
+> = gql`
   mutation AddPlanDagEdge($projectId: Int!, $planId: Int, $edge: PlanDagEdgeInput!) {
     addPlanDagEdge(projectId: $projectId, planId: $planId, edge: $edge) {
       id
@@ -177,7 +220,10 @@ export const ADD_PLAN_DAG_EDGE = gql`
   }
 `
 
-export const DELETE_PLAN_DAG_EDGE = gql`
+export const DELETE_PLAN_DAG_EDGE: TypedDocumentNode<
+  { deletePlanDagEdge: { id: string } },
+  { projectId: number; planId?: number | null; edgeId: string }
+> = gql`
   mutation DeletePlanDagEdge($projectId: Int!, $planId: Int, $edgeId: String!) {
     deletePlanDagEdge(projectId: $projectId, planId: $planId, edgeId: $edgeId) {
       id
@@ -185,7 +231,15 @@ export const DELETE_PLAN_DAG_EDGE = gql`
   }
 `
 
-export const UPDATE_PLAN_DAG_EDGE = gql`
+export const UPDATE_PLAN_DAG_EDGE: TypedDocumentNode<
+  { updatePlanDagEdge: PlanDagEdge },
+  {
+    projectId: number
+    planId?: number | null
+    edgeId: string
+    updates: unknown
+  }
+> = gql`
   mutation UpdatePlanDagEdge($projectId: Int!, $planId: Int, $edgeId: String!, $updates: PlanDagEdgeUpdateInput!) {
     updatePlanDagEdge(projectId: $projectId, planId: $planId, edgeId: $edgeId, updates: $updates) {
       id
@@ -199,7 +253,15 @@ export const UPDATE_PLAN_DAG_EDGE = gql`
   }
 `
 
-export const MOVE_PLAN_DAG_NODE = gql`
+export const MOVE_PLAN_DAG_NODE: TypedDocumentNode<
+  { movePlanDagNode: { id: string; position: { x: number; y: number } } },
+  {
+    projectId: number
+    planId?: number | null
+    nodeId: string
+    position: { x: number; y: number }
+  }
+> = gql`
   mutation MovePlanDagNode($projectId: Int!, $planId: Int, $nodeId: String!, $position: PositionInput!) {
     movePlanDagNode(projectId: $projectId, planId: $planId, nodeId: $nodeId, position: $position) {
       id
@@ -211,7 +273,14 @@ export const MOVE_PLAN_DAG_NODE = gql`
   }
 `
 
-export const BATCH_MOVE_PLAN_DAG_NODES = gql`
+export const BATCH_MOVE_PLAN_DAG_NODES: TypedDocumentNode<
+  { batchMovePlanDagNodes: Array<{ id: string; position: { x: number; y: number } }> },
+  {
+    projectId: number
+    planId?: number | null
+    nodePositions: unknown
+  }
+> = gql`
   mutation BatchMovePlanDagNodes($projectId: Int!, $planId: Int, $nodePositions: [NodePositionInput!]!) {
     batchMovePlanDagNodes(projectId: $projectId, planId: $planId, nodePositions: $nodePositions) {
       id
@@ -223,7 +292,22 @@ export const BATCH_MOVE_PLAN_DAG_NODES = gql`
   }
 `
 
-export const VALIDATE_AND_MIGRATE_PLAN_DAG = gql`
+export const VALIDATE_AND_MIGRATE_PLAN_DAG: TypedDocumentNode<
+  {
+    validateAndMigratePlanDag: {
+      checkedNodes: number
+      updatedNodes: Array<{
+        nodeId: string
+        fromType?: string | null
+        toType?: string | null
+        note?: string | null
+      }>
+      warnings: string[]
+      errors: string[]
+    }
+  },
+  { projectId: number; planId?: number | null }
+> = gql`
   mutation ValidateAndMigratePlanDag($projectId: Int!, $planId: Int) {
     validateAndMigratePlanDag(projectId: $projectId, planId: $planId) {
       checkedNodes
@@ -240,7 +324,10 @@ export const VALIDATE_AND_MIGRATE_PLAN_DAG = gql`
 `
 
 // Plan DAG Subscriptions for real-time collaboration
-export const PLAN_DAG_CHANGED_SUBSCRIPTION = gql`
+export const PLAN_DAG_CHANGED_SUBSCRIPTION: TypedDocumentNode<
+  { planDagChanged: Record<string, unknown> },
+  { projectId: number; planId?: number | null }
+> = gql`
   subscription PlanDagChanged($projectId: Int!, $planId: Int) {
     planDagChanged(projectId: $projectId, planId: $planId) {
       type
@@ -292,7 +379,10 @@ export const PLAN_DAG_CHANGED_SUBSCRIPTION = gql`
   }
 `
 
-export const USER_PRESENCE_SUBSCRIPTION = gql`
+export const USER_PRESENCE_SUBSCRIPTION: TypedDocumentNode<
+  { userPresenceChanged: Record<string, unknown> },
+  { planId: string }
+> = gql`
   subscription UserPresenceChanged($planId: ID!) {
     userPresenceChanged(planId: $planId) {
       userId
@@ -310,7 +400,10 @@ export const USER_PRESENCE_SUBSCRIPTION = gql`
 `
 
 // Delta-based subscription for JSON Patch updates
-export const PLAN_DAG_DELTA_SUBSCRIPTION = gql`
+export const PLAN_DAG_DELTA_SUBSCRIPTION: TypedDocumentNode<
+  { planDagDeltaChanged: Record<string, unknown> },
+  { projectId: number; planId?: number | null }
+> = gql`
   subscription PlanDagDeltaChanged($projectId: Int!, $planId: Int) {
     planDagDeltaChanged(projectId: $projectId, planId: $planId) {
       projectId
@@ -330,7 +423,10 @@ export const PLAN_DAG_DELTA_SUBSCRIPTION = gql`
 `
 
 // Execution status subscription for real-time status updates
-export const NODE_EXECUTION_STATUS_SUBSCRIPTION = gql`
+export const NODE_EXECUTION_STATUS_SUBSCRIPTION: TypedDocumentNode<
+  { nodeExecutionStatusChanged: Record<string, unknown> },
+  { projectId: number }
+> = gql`
   subscription NodeExecutionStatusChanged($projectId: Int!) {
     nodeExecutionStatusChanged(projectId: $projectId) {
       projectId
@@ -361,13 +457,19 @@ export const NODE_EXECUTION_STATUS_SUBSCRIPTION = gql`
 
 // Collaboration Mutations
 
-export const JOIN_PROJECT_COLLABORATION = gql`
+export const JOIN_PROJECT_COLLABORATION: TypedDocumentNode<
+  { joinProjectCollaboration: boolean },
+  { projectId: number }
+> = gql`
   mutation JoinProjectCollaboration($projectId: Int!) {
     joinProjectCollaboration(projectId: $projectId)
   }
 `
 
-export const LEAVE_PROJECT_COLLABORATION = gql`
+export const LEAVE_PROJECT_COLLABORATION: TypedDocumentNode<
+  { leaveProjectCollaboration: boolean },
+  { projectId: number }
+> = gql`
   mutation LeaveProjectCollaboration($projectId: Int!) {
     leaveProjectCollaboration(projectId: $projectId)
   }

--- a/frontend/src/graphql/plans.ts
+++ b/frontend/src/graphql/plans.ts
@@ -1,4 +1,5 @@
-import { gql } from '@apollo/client'
+import { gql, type TypedDocumentNode } from '@apollo/client'
+import type { Plan } from '../types/plan'
 
 const PLAN_FIELDS = gql`
   fragment PlanFields on Plan {
@@ -16,7 +17,10 @@ const PLAN_FIELDS = gql`
   }
 `
 
-export const LIST_PLANS = gql`
+export const LIST_PLANS: TypedDocumentNode<
+  { plans: Plan[] },
+  { projectId: number }
+> = gql`
   query Plans($projectId: Int!) {
     plans(projectId: $projectId) {
       ...PlanFields
@@ -25,7 +29,10 @@ export const LIST_PLANS = gql`
   ${PLAN_FIELDS}
 `
 
-export const GET_PLAN = gql`
+export const GET_PLAN: TypedDocumentNode<
+  { plan: Plan | null },
+  { id: number }
+> = gql`
   query GetPlan($id: Int!) {
     plan(id: $id) {
       ...PlanFields
@@ -34,7 +41,10 @@ export const GET_PLAN = gql`
   ${PLAN_FIELDS}
 `
 
-export const CREATE_PLAN = gql`
+export const CREATE_PLAN: TypedDocumentNode<
+  { createPlan: Plan },
+  { input: Record<string, unknown> }
+> = gql`
   mutation CreatePlan($input: CreatePlanInput!) {
     createPlan(input: $input) {
       ...PlanFields
@@ -43,7 +53,10 @@ export const CREATE_PLAN = gql`
   ${PLAN_FIELDS}
 `
 
-export const UPDATE_PLAN = gql`
+export const UPDATE_PLAN: TypedDocumentNode<
+  { updatePlan: Plan },
+  { id: number; input: Record<string, unknown> }
+> = gql`
   mutation UpdatePlan($id: Int!, $input: UpdatePlanInput!) {
     updatePlan(id: $id, input: $input) {
       ...PlanFields
@@ -52,13 +65,19 @@ export const UPDATE_PLAN = gql`
   ${PLAN_FIELDS}
 `
 
-export const DELETE_PLAN = gql`
+export const DELETE_PLAN: TypedDocumentNode<
+  { deletePlan: boolean },
+  { id: number }
+> = gql`
   mutation DeletePlan($id: Int!) {
     deletePlan(id: $id)
   }
 `
 
-export const DUPLICATE_PLAN = gql`
+export const DUPLICATE_PLAN: TypedDocumentNode<
+  { duplicatePlan: Plan },
+  { id: number; name: string }
+> = gql`
   mutation DuplicatePlan($id: Int!, $name: String!) {
     duplicatePlan(id: $id, name: $name) {
       ...PlanFields

--- a/frontend/src/graphql/preview.ts
+++ b/frontend/src/graphql/preview.ts
@@ -1,8 +1,11 @@
-import { gql } from '@apollo/client';
+import { gql, type TypedDocumentNode } from '@apollo/client';
 import { Layer } from './graphs';
 
 // DataSet Preview Query
-export const GET_DATASOURCE_PREVIEW = gql`
+export const GET_DATASOURCE_PREVIEW: TypedDocumentNode<
+  GetDataSetPreviewResponse,
+  GetDataSetPreviewVariables
+> = gql`
   query GetDataSetPreview(
     $projectId: Int!
     $nodeId: String!
@@ -38,7 +41,10 @@ export const GET_DATASOURCE_PREVIEW = gql`
 `;
 
 // Graph Preview Query
-export const GET_GRAPH_PREVIEW = gql`
+export const GET_GRAPH_PREVIEW: TypedDocumentNode<
+  GetGraphPreviewResponse,
+  GetGraphPreviewVariables
+> = gql`
   query GetGraphPreview($projectId: Int!, $nodeId: String!) {
     graphPreview(projectId: $projectId, nodeId: $nodeId) {
       nodeId
@@ -210,7 +216,10 @@ export function getExecutionStateLabel(state: string): string {
 }
 
 // Execute Node Mutation
-export const EXECUTE_NODE = gql`
+export const EXECUTE_NODE: TypedDocumentNode<
+  { executeNode: NodeExecutionResult },
+  { projectId: number; nodeId: string }
+> = gql`
   mutation ExecuteNode($projectId: Int!, $nodeId: String!) {
     executeNode(projectId: $projectId, nodeId: $nodeId) {
       success
@@ -227,7 +236,10 @@ export interface NodeExecutionResult {
 }
 
 // Execute Plan (DAG) Mutation
-export const EXECUTE_PLAN = gql`
+export const EXECUTE_PLAN: TypedDocumentNode<
+  { executePlan: PlanExecutionResult },
+  { projectId: number; planId: number }
+> = gql`
   mutation ExecutePlan($projectId: Int!, $planId: Int!) {
     executePlan(projectId: $projectId, planId: $planId) {
       success
@@ -244,7 +256,10 @@ export interface PlanExecutionResult {
 }
 
 // Clear Project Execution State Mutation (resets all graph data, keeps config and datasets)
-export const CLEAR_PROJECT_EXECUTION = gql`
+export const CLEAR_PROJECT_EXECUTION: TypedDocumentNode<
+  { clearProjectExecution: ExecutionActionResult },
+  { projectId: number }
+> = gql`
   mutation ClearProjectExecution($projectId: Int!) {
     clearProjectExecution(projectId: $projectId) {
       success
@@ -254,7 +269,10 @@ export const CLEAR_PROJECT_EXECUTION = gql`
 `;
 
 // Stop Plan Execution Mutation
-export const STOP_PLAN_EXECUTION = gql`
+export const STOP_PLAN_EXECUTION: TypedDocumentNode<
+  { stopPlanExecution: ExecutionActionResult },
+  { projectId: number }
+> = gql`
   mutation StopPlanExecution($projectId: Int!) {
     stopPlanExecution(projectId: $projectId) {
       success

--- a/frontend/src/graphql/sequences.ts
+++ b/frontend/src/graphql/sequences.ts
@@ -1,7 +1,10 @@
-import { gql } from '@apollo/client'
+import { gql, type TypedDocumentNode } from '@apollo/client'
 
 // Query to list all sequences for a story
-export const LIST_SEQUENCES = gql`
+export const LIST_SEQUENCES: TypedDocumentNode<
+  { sequences: Sequence[] },
+  { storyId: number }
+> = gql`
   query ListSequences($storyId: Int!) {
     sequences(storyId: $storyId) {
       id
@@ -23,7 +26,10 @@ export const LIST_SEQUENCES = gql`
 `
 
 // Query to get a single sequence by ID
-export const GET_SEQUENCE = gql`
+export const GET_SEQUENCE: TypedDocumentNode<
+  { sequence: Sequence | null },
+  { id: number }
+> = gql`
   query GetSequence($id: Int!) {
     sequence(id: $id) {
       id
@@ -45,7 +51,10 @@ export const GET_SEQUENCE = gql`
 `
 
 // Mutation to create a new sequence
-export const CREATE_SEQUENCE = gql`
+export const CREATE_SEQUENCE: TypedDocumentNode<
+  { createSequence: Sequence },
+  { input: CreateSequenceInput }
+> = gql`
   mutation CreateSequence($input: CreateSequenceInput!) {
     createSequence(input: $input) {
       id
@@ -67,7 +76,10 @@ export const CREATE_SEQUENCE = gql`
 `
 
 // Mutation to update a sequence
-export const UPDATE_SEQUENCE = gql`
+export const UPDATE_SEQUENCE: TypedDocumentNode<
+  { updateSequence: Sequence },
+  { id: number; input: UpdateSequenceInput }
+> = gql`
   mutation UpdateSequence($id: Int!, $input: UpdateSequenceInput!) {
     updateSequence(id: $id, input: $input) {
       id
@@ -89,7 +101,10 @@ export const UPDATE_SEQUENCE = gql`
 `
 
 // Mutation to delete a sequence
-export const DELETE_SEQUENCE = gql`
+export const DELETE_SEQUENCE: TypedDocumentNode<
+  { deleteSequence: boolean },
+  { id: number }
+> = gql`
   mutation DeleteSequence($id: Int!) {
     deleteSequence(id: $id)
   }
@@ -121,14 +136,14 @@ export interface Sequence {
 export interface CreateSequenceInput {
   storyId: number
   name: string
-  description?: string
+  description?: string | null
   enabledDatasetIds?: number[]
   edgeOrder?: SequenceEdgeRef[]
 }
 
 export interface UpdateSequenceInput {
   name?: string
-  description?: string
+  description?: string | null
   enabledDatasetIds?: number[]
   edgeOrder?: SequenceEdgeRef[]
 }

--- a/frontend/src/graphql/stories.ts
+++ b/frontend/src/graphql/stories.ts
@@ -1,7 +1,10 @@
-import { gql } from '@apollo/client'
+import { gql, type TypedDocumentNode } from '@apollo/client'
 
 // Query to list all stories for a project
-export const LIST_STORIES = gql`
+export const LIST_STORIES: TypedDocumentNode<
+  { stories: Story[] },
+  { projectId: number }
+> = gql`
   query ListStories($projectId: Int!) {
     stories(projectId: $projectId) {
       id
@@ -23,7 +26,10 @@ export const LIST_STORIES = gql`
 `
 
 // Query to get a single story by ID
-export const GET_STORY = gql`
+export const GET_STORY: TypedDocumentNode<
+  { story: Story | null },
+  { id: number }
+> = gql`
   query GetStory($id: Int!) {
     story(id: $id) {
       id
@@ -45,7 +51,10 @@ export const GET_STORY = gql`
 `
 
 // Mutation to create a new story
-export const CREATE_STORY = gql`
+export const CREATE_STORY: TypedDocumentNode<
+  { createStory: Story },
+  { input: CreateStoryInput }
+> = gql`
   mutation CreateStory($input: CreateStoryInput!) {
     createStory(input: $input) {
       id
@@ -67,7 +76,10 @@ export const CREATE_STORY = gql`
 `
 
 // Mutation to update a story
-export const UPDATE_STORY = gql`
+export const UPDATE_STORY: TypedDocumentNode<
+  { updateStory: Story },
+  { id: number; input: UpdateStoryInput }
+> = gql`
   mutation UpdateStory($id: Int!, $input: UpdateStoryInput!) {
     updateStory(id: $id, input: $input) {
       id
@@ -89,7 +101,10 @@ export const UPDATE_STORY = gql`
 `
 
 // Mutation to delete a story
-export const DELETE_STORY = gql`
+export const DELETE_STORY: TypedDocumentNode<
+  { deleteStory: boolean },
+  { id: number }
+> = gql`
   mutation DeleteStory($id: Int!) {
     deleteStory(id: $id)
   }
@@ -122,7 +137,7 @@ export interface Story {
 export interface CreateStoryInput {
   projectId: number
   name: string
-  description?: string
+  description?: string | null
   tags?: string[]
   enabledDatasetIds?: number[]
   enabledGraphIds?: number[]
@@ -131,7 +146,7 @@ export interface CreateStoryInput {
 
 export interface UpdateStoryInput {
   name?: string
-  description?: string
+  description?: string | null
   tags?: string[]
   enabledDatasetIds?: number[]
   enabledGraphIds?: number[]
@@ -140,7 +155,10 @@ export interface UpdateStoryInput {
 
 // Import/Export mutations
 
-export const EXPORT_STORY = gql`
+export const EXPORT_STORY: TypedDocumentNode<
+  { exportStory: StoryExport },
+  { storyId: number; format: StoryExportFormat }
+> = gql`
   mutation ExportStory($storyId: Int!, $format: StoryExportFormat!) {
     exportStory(storyId: $storyId, format: $format) {
       filename
@@ -150,7 +168,10 @@ export const EXPORT_STORY = gql`
   }
 `
 
-export const IMPORT_STORY = gql`
+export const IMPORT_STORY: TypedDocumentNode<
+  { importStory: StoryImportResult },
+  { projectId: number; format: StoryImportFormat; content: string }
+> = gql`
   mutation ImportStory($projectId: Int!, $format: StoryImportFormat!, $content: String!) {
     importStory(projectId: $projectId, format: $format, content: $content) {
       importedStories {

--- a/frontend/src/graphql/subscriptions.ts
+++ b/frontend/src/graphql/subscriptions.ts
@@ -1,7 +1,10 @@
-import { gql } from '@apollo/client'
+import { gql, type TypedDocumentNode } from '@apollo/client'
 
 // Plan DAG Update Subscription
-export const PLAN_DAG_UPDATED_SUBSCRIPTION = gql`
+export const PLAN_DAG_UPDATED_SUBSCRIPTION: TypedDocumentNode<
+  { planDagUpdated: PlanDagUpdateEvent },
+  { planId: string }
+> = gql`
   subscription PlanDagUpdated($planId: ID!) {
     planDagUpdated(planId: $planId) {
       planId
@@ -31,7 +34,10 @@ export const PLAN_DAG_UPDATED_SUBSCRIPTION = gql`
 `
 
 // User Presence Subscription
-export const USER_PRESENCE_CHANGED_SUBSCRIPTION = gql`
+export const USER_PRESENCE_CHANGED_SUBSCRIPTION: TypedDocumentNode<
+  { userPresenceChanged: UserPresenceEvent },
+  { planId: string }
+> = gql`
   subscription UserPresenceChanged($planId: ID!) {
     userPresenceChanged(planId: $planId) {
       userId
@@ -49,7 +55,10 @@ export const USER_PRESENCE_CHANGED_SUBSCRIPTION = gql`
 `
 
 // All Collaboration Events Subscription
-export const COLLABORATION_EVENTS_SUBSCRIPTION = gql`
+export const COLLABORATION_EVENTS_SUBSCRIPTION: TypedDocumentNode<
+  { collaborationEvents: CollaborationEvent },
+  { planId: string }
+> = gql`
   subscription CollaborationEvents($planId: ID!) {
     collaborationEvents(planId: $planId) {
       eventId

--- a/frontend/src/graphql/systemSettings.ts
+++ b/frontend/src/graphql/systemSettings.ts
@@ -1,4 +1,4 @@
-import { gql } from '@apollo/client'
+import { gql, type TypedDocumentNode } from '@apollo/client'
 
 export type SystemSettingValueType = 'String' | 'Text' | 'Url' | 'Integer' | 'Float' | 'Boolean' | 'Enum' | 'Secret'
 
@@ -23,7 +23,10 @@ export interface UpdateSystemSettingResponse {
   updateSystemSetting: SystemSetting
 }
 
-export const GET_SYSTEM_SETTINGS = gql`
+export const GET_SYSTEM_SETTINGS: TypedDocumentNode<
+  GetSystemSettingsResponse,
+  Record<string, never>
+> = gql`
   query GetSystemSettings {
     systemSettings {
       key
@@ -40,7 +43,10 @@ export const GET_SYSTEM_SETTINGS = gql`
   }
 `
 
-export const UPDATE_SYSTEM_SETTING = gql`
+export const UPDATE_SYSTEM_SETTING: TypedDocumentNode<
+  UpdateSystemSettingResponse,
+  { input: Record<string, unknown> }
+> = gql`
   mutation UpdateSystemSetting($input: SystemSettingUpdateInput!) {
     updateSystemSetting(input: $input) {
       key

--- a/frontend/src/hooks/usePreview.ts
+++ b/frontend/src/hooks/usePreview.ts
@@ -2,10 +2,6 @@ import { useQuery } from '@apollo/client/react';
 import {
   GET_DATASOURCE_PREVIEW,
   GET_GRAPH_PREVIEW,
-  GetDataSetPreviewResponse,
-  GetDataSetPreviewVariables,
-  GetGraphPreviewResponse,
-  GetGraphPreviewVariables,
   DataSetPreview,
   GraphPreview,
 } from '../graphql/preview';
@@ -27,10 +23,7 @@ export function useDataSetPreview(
 ) {
   const { limit = 100, offset = 0, skip = false } = options || {};
 
-  const { data, loading, error, refetch } = useQuery<
-    GetDataSetPreviewResponse,
-    GetDataSetPreviewVariables
-  >(GET_DATASOURCE_PREVIEW, {
+  const { data, loading, error, refetch } = useQuery(GET_DATASOURCE_PREVIEW, {
     variables: {
       projectId,
       nodeId,
@@ -64,10 +57,7 @@ export function useGraphPreview(
 ) {
   const { skip = false } = options || {};
 
-  const { data, loading, error, refetch } = useQuery<
-    GetGraphPreviewResponse,
-    GetGraphPreviewVariables
-  >(GET_GRAPH_PREVIEW, {
+  const { data, loading, error, refetch } = useQuery(GET_GRAPH_PREVIEW, {
     variables: {
       projectId,
       nodeId,

--- a/frontend/src/hooks/useProjectPlanSelection.ts
+++ b/frontend/src/hooks/useProjectPlanSelection.ts
@@ -40,7 +40,7 @@ export const useProjectPlanSelection = (projectId: number): UseProjectPlanSelect
     loading,
     error,
     refetch,
-  } = useQuery<{ plans: Plan[] }>(LIST_PLANS, {
+  } = useQuery(LIST_PLANS, {
     variables: { projectId },
     skip: !projectId,
     fetchPolicy: 'cache-and-network',

--- a/frontend/src/pages/GraphEditorPage.tsx
+++ b/frontend/src/pages/GraphEditorPage.tsx
@@ -2,14 +2,14 @@ import React, { useState, useCallback, useEffect, useRef, useMemo } from 'react'
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { IconAlertCircle, IconArrowLeft, IconHistory, IconEdit, IconDownload, IconRoute, IconZoomScan, IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
 import { useQuery, useMutation } from '@apollo/client/react';
-import { gql } from '@apollo/client';
+import { gql, type TypedDocumentNode } from '@apollo/client';
 import { Breadcrumbs } from '../components/common/Breadcrumbs';
 import { LayercakeGraphEditor, GraphViewMode, GraphOrientation, HierarchyViewMode } from '../components/graphs/LayercakeGraphEditor';
 import { PropertiesAndLayersPanel } from '../components/graphs/PropertiesAndLayersPanel';
 import EditHistoryModal from '../components/graphs/EditHistoryModal';
 import { ReactFlowProvider, Node as FlowNode, Edge as FlowEdge } from 'reactflow';
 import { Graph, GraphNode, UPDATE_GRAPH_NODE, GET_GRAPH_EDIT_COUNT, ADD_GRAPH_NODE, ADD_GRAPH_EDGE, UPDATE_GRAPH_EDGE, DELETE_GRAPH_EDGE, DELETE_GRAPH_NODE } from '../graphql/graphs';
-import { GET_DATASOURCES, UPDATE_DATASOURCE_GRAPH_DATA, DataSet } from '../graphql/datasets';
+import { GET_DATASOURCES, UPDATE_DATASOURCE_GRAPH_DATA } from '../graphql/datasets';
 import { Stack, Group } from '../components/layout-primitives';
 import { Alert, AlertDescription, AlertTitle } from '../components/ui/alert';
 import { Badge } from '../components/ui/badge';
@@ -32,7 +32,10 @@ declare global {
   }
 }
 
-const GET_PROJECTS = gql`
+const GET_PROJECTS: TypedDocumentNode<
+  { projects: Array<{ id: number; name: string }> },
+  Record<string, never>
+> = gql`
   query GetProjects {
     projects {
       id
@@ -41,7 +44,10 @@ const GET_PROJECTS = gql`
   }
 `;
 
-const GET_GRAPH_DETAILS = gql`
+const GET_GRAPH_DETAILS: TypedDocumentNode<
+  { graph: Graph | null },
+  { id: number }
+> = gql`
   query GetGraphDetails($id: Int!) {
     graph(id: $id) {
       id
@@ -115,11 +121,11 @@ export const GraphEditorPage: React.FC<GraphEditorPageProps> = () => {
   const setNodesRef = useRef<React.Dispatch<React.SetStateAction<FlowNode[]>> | null>(null);
   const setEdgesRef = useRef<React.Dispatch<React.SetStateAction<FlowEdge[]>> | null>(null);
 
-  const { data: projectsData } = useQuery<{ projects: Array<{ id: number; name: string }> }>(GET_PROJECTS);
-  const selectedProject = projectsData?.projects.find((p: { id: number; name: string }) => p.id === parseInt(projectId || '0'));
+  const { data: projectsData } = useQuery(GET_PROJECTS);
+  const selectedProject = projectsData?.projects?.find((p: { id: number; name: string }) => p.id === parseInt(projectId || '0'));
 
   // Fetch datasets for target dataset selection
-  const { data: datasetsData } = useQuery<{ dataSets: DataSet[] }>(GET_DATASOURCES, {
+  const { data: datasetsData } = useQuery(GET_DATASOURCES, {
     variables: { projectId: parseInt(projectId || '0') },
     skip: !projectId,
   });
@@ -127,12 +133,12 @@ export const GraphEditorPage: React.FC<GraphEditorPageProps> = () => {
 
   const [updateDatasetGraphData] = useMutation(UPDATE_DATASOURCE_GRAPH_DATA);
 
-  const { data: graphData, loading: graphLoading, error: graphError } = useQuery<{ graph: Graph }, { id: number }>(GET_GRAPH_DETAILS, {
+  const { data: graphData, loading: graphLoading, error: graphError } = useQuery(GET_GRAPH_DETAILS, {
     variables: { id: parseInt(graphId || '0') },
     skip: !graphId,
   });
 
-  const { data: editCountData, refetch: refetchEditCount } = useQuery<{ graphEditCount: number }, { graphId: number; unappliedOnly: boolean }>(
+  const { data: editCountData, refetch: refetchEditCount } = useQuery(
     GET_GRAPH_EDIT_COUNT,
     {
       variables: { graphId: parseInt(graphId || '0'), unappliedOnly: true },
@@ -343,7 +349,7 @@ export const GraphEditorPage: React.FC<GraphEditorPageProps> = () => {
         nodeId,
         label: updates.label,
         layer: updates.layer,
-        attrs: updates.attrs,
+        attributes: updates.attrs,
         belongsTo: updates.belongsTo,
       },
     }).catch(error => {
@@ -425,10 +431,10 @@ export const GraphEditorPage: React.FC<GraphEditorPageProps> = () => {
         id: edge.id,
         source: edge.source,
         target: edge.target,
-        label: edge.label,
+        label: typeof edge.label === 'string' ? edge.label : undefined,
         layer: edge.data?.layer,
         weight: edge.data?.weight,
-        attrs: edge.data?.attrs,
+        attributes: edge.data?.attrs,
       },
     }).catch(error => {
       console.error('Failed to add edge:', error);
@@ -471,7 +477,7 @@ export const GraphEditorPage: React.FC<GraphEditorPageProps> = () => {
         isPartition: node.data?.isPartition || false,
         belongsTo: belongsTo,
         weight: node.data?.weight,
-        attrs: node.data?.attrs,
+        attributes: node.data?.attrs,
       },
     }).catch(error => {
       console.error('Failed to add node:', error);

--- a/frontend/src/pages/ProjectArtefactsPage.tsx
+++ b/frontend/src/pages/ProjectArtefactsPage.tsx
@@ -17,7 +17,7 @@ import {
   IconExternalLink,
   IconPresentation,
 } from '@tabler/icons-react'
-import { gql } from '@apollo/client'
+import { gql, type TypedDocumentNode } from '@apollo/client'
 import { GET_PLAN_DAG, UPDATE_PLAN_DAG_NODE } from '../graphql/plan-dag'
 import { EXPORT_NODE_OUTPUT } from '../graphql/export'
 import { Stack, Group } from '../components/layout-primitives'
@@ -45,7 +45,10 @@ import { useProjectPlanSelection } from '../hooks/useProjectPlanSelection'
 import { fallbackExportFilename } from '../utils/exportFilename'
 import { cn } from '../lib/utils'
 
-const GET_PROJECTS = gql`
+const GET_PROJECTS: TypedDocumentNode<
+  { projects: Array<{ id: number; name: string }> },
+  Record<string, never>
+> = gql`
   query GetProjects {
     projects {
       id
@@ -68,13 +71,6 @@ type PlanDagEdge = {
   id: string
   source: string
   target: string
-}
-
-type PlanDagResponse = {
-  getPlanDag: {
-    nodes: PlanDagNode[]
-    edges: PlanDagEdge[]
-  }
 }
 
 type ArtefactEntry =
@@ -142,7 +138,7 @@ const ProjectArtefactsPage: React.FC = () => {
   const projectIdNum = Number(projectId || 0)
   const projectIdParam = projectId ?? (projectIdNum ? String(projectIdNum) : '')
 
-  const { data: projectsData } = useQuery<{ projects: Array<{ id: number; name: string }> }>(GET_PROJECTS)
+  const { data: projectsData } = useQuery(GET_PROJECTS)
   const selectedProject = projectsData?.projects.find((p: { id: number; name: string }) => p.id === projectIdNum)
 
   const {
@@ -160,7 +156,7 @@ const ProjectArtefactsPage: React.FC = () => {
     navigate(`/projects/${selectedProject.id}/plans`)
   }
 
-  const { data, loading: planDagLoading, error } = useQuery<PlanDagResponse>(GET_PLAN_DAG, {
+  const { data, loading: planDagLoading, error } = useQuery(GET_PLAN_DAG, {
     variables: { projectId: projectIdNum, planId: selectedPlanId },
     fetchPolicy: 'cache-and-network',
     skip: !selectedPlanId,
@@ -319,8 +315,8 @@ const [exportForPreview] = useMutation(EXPORT_NODE_OUTPUT, {
   })
 
   const entries = useMemo<ArtefactEntry[]>(() => {
-    const nodes = data?.getPlanDag?.nodes ?? []
-    const edges = data?.getPlanDag?.edges ?? []
+    const nodes = (data?.getPlanDag?.nodes ?? []) as unknown as PlanDagNode[]
+    const edges = (data?.getPlanDag?.edges ?? []) as unknown as PlanDagEdge[]
     if (!nodes.length) return []
 
     const nodeMap = new Map(nodes.map((node) => [node.id, node]))

--- a/frontend/src/pages/ProjectLayersPage.tsx
+++ b/frontend/src/pages/ProjectLayersPage.tsx
@@ -1,7 +1,7 @@
 import { Fragment, useEffect, useMemo, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useMutation, useQuery } from '@apollo/client/react'
-import { gql } from '@apollo/client'
+import { gql, type TypedDocumentNode } from '@apollo/client'
 import { hexToRgb } from '@/utils/color'
 import { Breadcrumbs } from '@/components/common/Breadcrumbs'
 import PageContainer from '@/components/layout/PageContainer'
@@ -148,6 +148,18 @@ const normalizeHexValue = (value: string, fallback: string) => {
   return value.startsWith('#') ? value : `#${value.replace(/^#/, '')}`
 }
 
+const LAYERS_PROJECT_NAME: TypedDocumentNode<
+  { project: { id: number; name: string } | null },
+  { id: number }
+> = gql`
+  query LayersProjectName($id: Int!) {
+    project(id: $id) {
+      id
+      name
+    }
+  }
+`
+
 export const ProjectLayersPage = () => {
   const navigate = useNavigate()
   const { projectId } = useParams<{ projectId: string }>()
@@ -172,20 +184,10 @@ export const ProjectLayersPage = () => {
     }
   )
 
-  const { data: projectInfo } = useQuery<{ project: { id: number; name: string } | null }>(
-    gql`
-      query LayersProjectName($id: Int!) {
-        project(id: $id) {
-          id
-          name
-        }
-      }
-    `,
-    {
-      variables: { id: projectIdNum },
-      skip: !projectIdNum,
-    }
-  )
+  const { data: projectInfo } = useQuery(LAYERS_PROJECT_NAME, {
+    variables: { id: projectIdNum },
+    skip: !projectIdNum,
+  })
   const projectName = projectInfo?.project?.name ?? `Project ${projectIdNum}`
 
   const [upsertLayer, { loading: upserting }] = useMutation(UPSERT_PROJECT_LAYER)
@@ -198,16 +200,16 @@ export const ProjectLayersPage = () => {
   const [updateAutoPaletteGraph] = useMutation(UPDATE_DATASOURCE_GRAPH_DATA)
 
   const projectLayers: ProjectLayer[] = useMemo(
-    () => ((layersData as any)?.projectLayers as ProjectLayer[] | undefined) ?? [],
+    () => layersData?.projectLayers ?? [],
     [layersData]
   )
   const missingLayers: string[] = useMemo(
-    () => ((layersData as any)?.missingLayers as string[] | undefined) ?? [],
+    () => layersData?.missingLayers ?? [],
     [layersData]
   )
   // Filter to only show datasets with layer data
   const layerDatasets = useMemo(() => {
-    const allDataSets: any[] = ((datasetsData as any)?.dataSets as any[] | undefined) ?? []
+    const allDataSets: any[] = datasetsData?.dataSets ?? []
     return allDataSets.filter((ds) => {
       try {
         const parsed = JSON.parse(ds.graphJson ?? '{}')

--- a/frontend/src/pages/ProjectSharingPage.tsx
+++ b/frontend/src/pages/ProjectSharingPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { gql } from '@apollo/client'
+import { gql, type TypedDocumentNode } from '@apollo/client'
 import { useQuery } from '@apollo/client/react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { IconShare, IconLink, IconUsersGroup } from '@tabler/icons-react'
@@ -11,7 +11,18 @@ import { Stack, Group } from '../components/layout-primitives'
 import { Button } from '../components/ui/button'
 import { Input } from '../components/ui/input'
 
-const GET_PROJECTS = gql`
+const GET_PROJECTS: TypedDocumentNode<
+  {
+    projects: Array<{
+      id: number
+      name: string
+      description: string | null
+      createdAt: string
+      updatedAt: string
+    }>
+  },
+  Record<string, never>
+> = gql`
   query GetProjects {
     projects {
       id
@@ -28,11 +39,9 @@ export const ProjectSharingPage: React.FC = () => {
   const { projectId } = useParams<{ projectId: string }>()
   const projectNumericId = projectId ? parseInt(projectId, 10) : NaN
 
-  const { data: projectsData, loading: projectsLoading } = useQuery<{
-    projects: Array<{ id: number; name: string }>
-  }>(GET_PROJECTS)
+  const { data: projectsData, loading: projectsLoading } = useQuery(GET_PROJECTS)
   const selectedProject = projectsData?.projects.find(
-    (p: any) => p.id === projectNumericId,
+    (p) => p.id === projectNumericId,
   )
 
   if (projectsLoading && !selectedProject) {

--- a/frontend/src/pages/SequenceEditorPage.tsx
+++ b/frontend/src/pages/SequenceEditorPage.tsx
@@ -140,7 +140,7 @@ export const SequenceEditorPage = () => {
   const story: Story | null = (storyData as any)?.story || null
 
   const { data: sequenceData, loading: sequenceLoading } = useQuery(GET_SEQUENCE, {
-    variables: { id: sequenceIdNum },
+    variables: { id: sequenceIdNum ?? 0 },
     skip: !sequenceIdNum,
   })
   const sequence: Sequence | null = (sequenceData as any)?.sequence || null

--- a/frontend/src/pages/SourceManagementPage.tsx
+++ b/frontend/src/pages/SourceManagementPage.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
-import { gql } from '@apollo/client'
+import { gql, type TypedDocumentNode } from '@apollo/client'
 import { useMutation, useQuery } from '@apollo/client/react'
 import {
   IconDatabase,
@@ -28,7 +28,10 @@ import { Separator } from '../components/ui/separator'
 import { showSuccessNotification } from '../utils/notifications'
 import { handleMutationErrors } from '../utils/graphqlHelpers'
 
-const SOURCE_MANAGEMENT_QUERY = gql`
+const SOURCE_MANAGEMENT_QUERY: TypedDocumentNode<
+  SourceManagementResponse,
+  { projectId: number; fileScope?: string | null }
+> = gql`
   query SourceManagement($projectId: Int!, $fileScope: String) {
     dataAcquisitionFiles(projectId: $projectId) {
       id
@@ -49,7 +52,17 @@ const SOURCE_MANAGEMENT_QUERY = gql`
   }
 `
 
-const INGEST_FILE = gql`
+const INGEST_FILE: TypedDocumentNode<
+  {
+    ingestFile: {
+      fileId: string
+      checksum: string
+      chunkCount: number
+      indexed: boolean
+    }
+  },
+  { input: Record<string, unknown> }
+> = gql`
   mutation IngestFile($input: IngestFileInput!) {
     ingestFile(input: $input) {
       fileId
@@ -60,7 +73,10 @@ const INGEST_FILE = gql`
   }
 `
 
-const UPDATE_FILE = gql`
+const UPDATE_FILE: TypedDocumentNode<
+  { updateIngestedFile: ProjectFile },
+  { input: Record<string, unknown> }
+> = gql`
   mutation UpdateIngestedFile($input: UpdateIngestedFileInput!) {
     updateIngestedFile(input: $input) {
       id
@@ -75,19 +91,34 @@ const UPDATE_FILE = gql`
   }
 `
 
-const DELETE_FILE = gql`
+const DELETE_FILE: TypedDocumentNode<
+  { deleteFile: boolean },
+  { input: Record<string, unknown> }
+> = gql`
   mutation DeleteFile($input: DeleteFileInput!) {
     deleteFile(input: $input)
   }
 `
 
-const TOGGLE_FILE_INDEX = gql`
+const TOGGLE_FILE_INDEX: TypedDocumentNode<
+  { toggleFileIndex: boolean },
+  { input: Record<string, unknown> }
+> = gql`
   mutation ToggleFileIndex($input: ToggleFileIndexInput!) {
     toggleFileIndex(input: $input)
   }
 `
 
-const GET_FILE_CONTENT = gql`
+const GET_FILE_CONTENT: TypedDocumentNode<
+  {
+    getFileContent: {
+      filename: string
+      mediaType: string
+      content: string
+    }
+  },
+  { input: Record<string, unknown> }
+> = gql`
   mutation GetFileContent($input: GetFileContentInput!) {
     getFileContent(input: $input) {
       filename
@@ -97,7 +128,18 @@ const GET_FILE_CONTENT = gql`
   }
 `
 
-const GET_PROJECTS = gql`
+const GET_PROJECTS: TypedDocumentNode<
+  {
+    projects: Array<{
+      id: number
+      name: string
+      description?: string | null
+      createdAt: string
+      updatedAt: string
+    }>
+  },
+  Record<string, never>
+> = gql`
   query GetProjects {
     projects {
       id
@@ -152,11 +194,9 @@ export const SourceManagementPage: React.FC = () => {
   const { projectId } = useParams<{ projectId: string }>()
   const numericProjectId = projectId ? parseInt(projectId, 10) : NaN
 
-  const { data: projectsData, loading: projectsLoading } = useQuery<{
-    projects: Array<{ id: number; name: string }>
-  }>(GET_PROJECTS)
+  const { data: projectsData, loading: projectsLoading } = useQuery(GET_PROJECTS)
   const selectedProject = projectsData?.projects.find(
-    (p: any) => p.id === numericProjectId,
+    (p) => p.id === numericProjectId,
   )
 
   const [tagInput, setTagInput] = useState('')
@@ -166,7 +206,7 @@ export const SourceManagementPage: React.FC = () => {
   const [editFilename, setEditFilename] = useState('')
   const [editTags, setEditTags] = useState('')
 
-  const { data, loading, refetch } = useQuery<SourceManagementResponse>(
+  const { data, loading, refetch } = useQuery(
     SOURCE_MANAGEMENT_QUERY,
     {
       variables: {
@@ -295,7 +335,7 @@ export const SourceManagementPage: React.FC = () => {
       return
     }
 
-    const data = (result.data as any)?.getFileContent
+    const data = result.data?.getFileContent
     if (data) {
       // Decode base64 and create download
       const bytes = atob(data.content)

--- a/frontend/src/pages/SystemSettingsPage.tsx
+++ b/frontend/src/pages/SystemSettingsPage.tsx
@@ -6,7 +6,6 @@ import {
   SystemSetting,
   SystemSettingValueType,
   UPDATE_SYSTEM_SETTING,
-  GetSystemSettingsResponse,
 } from '../graphql/systemSettings'
 import { showErrorNotification, showSuccessNotification } from '../utils/notifications'
 import PageContainer from '../components/layout/PageContainer'
@@ -25,7 +24,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '.
 import { Textarea } from '../components/ui/textarea'
 
 export const SystemSettingsPage: React.FC = () => {
-  const { data, loading, error, refetch } = useQuery<GetSystemSettingsResponse>(GET_SYSTEM_SETTINGS)
+  const { data, loading, error, refetch } = useQuery(GET_SYSTEM_SETTINGS)
   const [updateSetting, { loading: saving }] = useMutation(UPDATE_SYSTEM_SETTING)
   const [selectedSetting, setSelectedSetting] = useState<SystemSetting | null>(null)
   const [value, setValue] = useState('')

--- a/frontend/src/pages/WorkbenchPage.tsx
+++ b/frontend/src/pages/WorkbenchPage.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useQuery, useMutation } from '@apollo/client/react'
-import { gql } from '@apollo/client'
+import { gql, type TypedDocumentNode } from '@apollo/client'
 import { Breadcrumbs } from '@/components/common/Breadcrumbs'
 import PageContainer from '@/components/layout/PageContainer'
 import { Group } from '@/components/layout-primitives'
@@ -22,9 +22,19 @@ import {
 import { showErrorNotification, showSuccessNotification } from '@/utils/notifications'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { useProjectPlanSelection } from '@/hooks/useProjectPlanSelection'
-import { LIST_STORIES, type Story } from '@/graphql/stories'
+import { LIST_STORIES } from '@/graphql/stories'
 
-const GET_PROJECTS = gql`
+interface WorkbenchProject {
+  id: number
+  name: string
+  description?: string | null
+  updatedAt?: string | null
+}
+
+const GET_PROJECTS: TypedDocumentNode<
+  { projects: WorkbenchProject[] },
+  Record<string, never>
+> = gql`
   query GetProjectsForWorkbench {
     projects {
       id
@@ -41,9 +51,9 @@ export const WorkbenchPage = () => {
   const projectIdNum = Number(projectId || 0)
 
   const { data: projectsData, loading: projectsLoading } = useQuery(GET_PROJECTS)
-  const projects = (projectsData as any)?.projects || []
+  const projects = projectsData?.projects ?? []
   const project = useMemo(
-    () => projects.find((p: any) => p.id === projectIdNum),
+    () => projects.find((p) => p.id === projectIdNum),
     [projects, projectIdNum]
   )
 
@@ -53,7 +63,7 @@ export const WorkbenchPage = () => {
     loading: plansLoading,
     selectPlan,
   } = useProjectPlanSelection(projectIdNum)
-  const { data: storiesData, loading: storiesLoading } = useQuery<{ stories: Story[] }>(LIST_STORIES, {
+  const { data: storiesData, loading: storiesLoading } = useQuery(LIST_STORIES, {
     variables: { projectId: projectIdNum },
     skip: !projectIdNum,
     fetchPolicy: 'cache-and-network',
@@ -75,7 +85,7 @@ export const WorkbenchPage = () => {
       const { data } = await resetProjectMutation({
         variables: { projectId: projectIdNum },
       })
-      const result = (data as any)?.resetProject
+      const result = data?.resetProject
 
       if (result) {
         showSuccessNotification(

--- a/frontend/src/pages/projections/ProjectionEditPage.tsx
+++ b/frontend/src/pages/projections/ProjectionEditPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
-import { gql } from '@apollo/client'
+import { gql, type TypedDocumentNode } from '@apollo/client'
 import { useLazyQuery, useMutation, useQuery } from '@apollo/client/react'
 import PageContainer from '@/components/layout/PageContainer'
 import { Breadcrumbs } from '@/components/common/Breadcrumbs'
@@ -16,7 +16,25 @@ import { createApolloClientForEndpoint } from '@/graphql/client'
 import { LIST_STORIES } from '@/graphql/stories'
 import { LIST_SEQUENCES } from '@/graphql/sequences'
 
-const PROJECTION_EDIT_QUERY = gql`
+type ProjectionEditData = {
+  projection: {
+    id: string
+    name: string
+    projectionType: string
+    projectId: string
+    graphId: string
+  } | null
+  projectionState: {
+    projectionId: string
+    projectionType: string
+    stateJson: Record<string, unknown> | null
+  } | null
+}
+
+const PROJECTION_EDIT_QUERY: TypedDocumentNode<
+  ProjectionEditData,
+  { id: string | undefined }
+> = gql`
   query ProjectionEdit($id: ID!) {
     projection(id: $id) {
       id
@@ -33,13 +51,35 @@ const PROJECTION_EDIT_QUERY = gql`
   }
 `
 
-const SAVE_PROJECTION_STATE = gql`
+const SAVE_PROJECTION_STATE: TypedDocumentNode<
+  { saveProjectionState: boolean },
+  { id: string; state: unknown }
+> = gql`
   mutation SaveProjectionState($id: ID!, $state: JSON!) {
     saveProjectionState(id: $id, state: $state)
   }
 `
 
-const VERIFY_PROJECTION_STORY_MATCH = gql`
+type VerifyProjectionStoryMatchData = {
+  verifyProjectionStoryMatch: {
+    success: boolean
+    sequences: {
+      storyId: number
+      sequenceId: number
+      missingEdges: { datasetId: number; edgeId: string }[]
+    }[]
+  } | null
+}
+
+type ProjectionStorySelectionInput = {
+  storyId: number
+  enabledSequenceIds: number[]
+}
+
+const VERIFY_PROJECTION_STORY_MATCH: TypedDocumentNode<
+  VerifyProjectionStoryMatchData,
+  { projectionId: number; stories: ProjectionStorySelectionInput[] }
+> = gql`
   mutation VerifyProjectionStoryMatch($projectionId: Int!, $stories: [ProjectionStorySelectionInput!]!) {
     verifyProjectionStoryMatch(projectionId: $projectionId, stories: $stories) {
       success
@@ -61,7 +101,6 @@ type StorySelection = {
 }
 
 type SequenceInfo = { id: number; name: string }
-type SequencesQueryResult = { sequences: SequenceInfo[] }
 
 const buildSelectionPayload = (selections: Record<number, StorySelection>) =>
   Object.entries(selections)
@@ -100,21 +139,18 @@ export const ProjectionEditPage = () => {
     skip: !projectIdNum,
   })
 
-  const [loadSequences, { loading: loadingSeq }] = useLazyQuery<SequencesQueryResult, { storyId: number }>(
-    LIST_SEQUENCES,
-    {
-      fetchPolicy: 'cache-first',
-    }
-  )
+  const [loadSequences, { loading: loadingSeq }] = useLazyQuery(LIST_SEQUENCES, {
+    fetchPolicy: 'cache-first',
+  })
 
   const [saveState, { loading: saving }] = useMutation(SAVE_PROJECTION_STATE, {
     client: projectionsClient,
   })
   const [verifyStories, { loading: verifying }] = useMutation(VERIFY_PROJECTION_STORY_MATCH)
 
-  const projection = (projectionData as any)?.projection
-  const projectionState = (projectionData as any)?.projectionState
-  const stories = (storiesData as any)?.stories ?? []
+  const projection = projectionData?.projection
+  const projectionState = projectionData?.projectionState
+  const stories = storiesData?.stories ?? []
 
   const [storyModeEnabled, setStoryModeEnabled] = useState(false)
   const [storySelections, setStorySelections] = useState<Record<number, StorySelection>>({})
@@ -237,12 +273,12 @@ export const ProjectionEditPage = () => {
       const { data } = await verifyStories({
         variables: { projectionId: projectionIdNum, stories: selection },
       })
-      const result = (data as any)?.verifyProjectionStoryMatch
+      const result = data?.verifyProjectionStoryMatch
       if (!result) {
         showErrorNotification('Verification failed', 'No result returned')
         return
       }
-      const missing = (result.sequences as any[]) ?? []
+      const missing = result.sequences ?? []
       setVerificationResult({ success: result.success, missing })
       if (result.success || missing.length === 0) {
         showSuccessNotification('Verified', 'All selected stories match this projection graph.')


### PR DESCRIPTION
## Summary

Completes the Apollo Client **4.0.5 → 4.2.7** migration deferred from the mermaid upgrade (`layercake-tool-aa7`), using a **structural** approach: type every gql document once and let the hooks infer.

### What changed
- **`@apollo/client` 4.0.5 → 4.2.7**, plus the required `ApolloClient.DeclareDefaultOptions` module augmentation for our `errorPolicy: 'all'` defaults.
- **`TypedDocumentNode<Data, Vars>` on every document** in `src/graphql/*.ts` — one source of truth per operation. Inline `useQuery<{...}>` / `useMutation<{...}>` generics removed at all call sites; data + variables now infer from the document.
- **Null-guards** where Apollo 4.2 correctly makes query `data` possibly-undefined (optional chaining + `?? default`).
- **Nullable id variables** (`graphId`/`dataSetId`/`storyId`/`sequenceIdNum`) coerced to `number` where the typed document requires one — the existing `skip` already prevents the query running with the sentinel.
- Opaque GraphQL input-object variables widened to `unknown`; nullable `*Input.description` widened to `string | null`.

### Latent bug fixed
Typing surfaced that `GraphEditorPage` sent an **`attrs`** variable to `addGraphNode`/`addGraphEdge`/`updateGraphNode`, but those operations only declare **`$attributes`** — so the field was **silently dropped** (node/edge attributes never persisted on add/update). Renamed to `attributes:` so the data actually flows. Also coerced a reactflow `ReactNode` edge label to `string`.

No GraphQL query text was changed; behaviour is preserved except the attributes fix.

### How
The 32-file document-typing + call-site sweep was done with a multi-agent workflow (2 phases: type documents → fix call sites), then I resolved the 31 residual cross-file type errors by hand (mostly stricter-than-payload input types and the nullable-variable coercions).

## Testing
- `tsc --noEmit` ✓ (0 errors)
- `npm run build` ✓ (Apollo 4.2.7)
- `cargo build -p layercake-server` implicitly green (embedded bundle rebuilds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)