### PR TITLE
fix(projections): clean not-found for deleted projection in viewer

### DIFF
--- a/layercake-projections/src/graphql.rs
+++ b/layercake-projections/src/graphql.rs
@@ -50,25 +50,30 @@ impl ProjectionQuery {
         Ok(model.map(Projection::from))
     }
 
-    async fn projection_graph(&self, ctx: &Context<'_>, id: ID) -> Result<ProjectionGraph> {
+    /// Returns `null` when the projection (or its graph) doesn't exist, so a
+    /// deleted projection renders the client's "not found" state rather than
+    /// surfacing a top-level GraphQL error. Real DB errors still propagate.
+    async fn projection_graph(&self, ctx: &Context<'_>, id: ID) -> Result<Option<ProjectionGraph>> {
         let service = ctx.data::<ProjectionSchemaContext>()?;
         let id: i32 = id
             .parse()
             .map_err(|_| Error::new("invalid projection id"))?;
-        let graph = service.projections.load_graph(id).await?;
-        Ok(ProjectionGraph::from(graph))
+        match service.projections.load_graph(id).await {
+            Ok(graph) => Ok(Some(ProjectionGraph::from(graph))),
+            Err(sea_orm::DbErr::RecordNotFound(_)) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
     }
 
-    async fn projection_state(&self, ctx: &Context<'_>, id: ID) -> Result<ProjectionState> {
+    /// Returns `null` when the projection doesn't exist (see `projection_graph`).
+    async fn projection_state(&self, ctx: &Context<'_>, id: ID) -> Result<Option<ProjectionState>> {
         let service = ctx.data::<ProjectionSchemaContext>()?;
         let id: i32 = id
             .parse()
             .map_err(|_| Error::new("invalid projection id"))?;
-        let model = service
-            .projections
-            .get(id)
-            .await?
-            .ok_or_else(|| Error::new("projection not found"))?;
+        let Some(model) = service.projections.get(id).await? else {
+            return Ok(None);
+        };
 
         let state = service
             .projections
@@ -76,11 +81,11 @@ impl ProjectionQuery {
             .await
             .or(model.settings_json);
 
-        Ok(ProjectionState {
+        Ok(Some(ProjectionState {
             projection_id: ID::from(id.to_string()),
             projection_type: model.projection_type,
             state_json: state.map(Json),
-        })
+        }))
     }
 }
 

--- a/layercake-projections/tests/projection_service_test.rs
+++ b/layercake-projections/tests/projection_service_test.rs
@@ -349,6 +349,23 @@ async fn test_load_graph() {
 }
 
 #[tokio::test]
+async fn test_missing_projection_is_graceful() {
+    // A deleted/nonexistent projection must be distinguishable so the GraphQL
+    // layer can return null rather than a top-level error: `get` yields None
+    // and `load_graph` yields RecordNotFound (which the resolver maps to null).
+    let db = setup_db().await;
+    let service = ProjectionService::new(db);
+
+    let missing_id = 999_999;
+    assert!(service.get(missing_id).await.unwrap().is_none());
+
+    match service.load_graph(missing_id).await {
+        Err(sea_orm::DbErr::RecordNotFound(_)) => {}
+        other => panic!("expected RecordNotFound for a missing projection, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn test_save_and_get_state() {
     let db = setup_db().await;
     let graph_id = seed_graph_data(&db).await;


### PR DESCRIPTION
## Summary

Loading `/projections/viewer/:id` for a **deleted** projection (e.g. 33) errored with `CombinedGraphQLErrors: RecordNotFound Error: projection 33` in the console instead of showing the viewer's existing "Projection not found" screen.

## Root cause

The viewer's `PROJECTION_QUERY` bundles three fields against the `/projections/graphql` endpoint:
- `projection(id)` — returned `null` gracefully (the not-found UI keys off this)
- `projectionGraph(id)` — **threw** `RecordNotFound` (service `load_graph`)
- `projectionState(id)` — **threw** "projection not found"

When a bundled field throws, GraphQL returns a top-level error for the whole operation, so the friendly not-found state never rendered cleanly.

(The record genuinely didn't exist — projection IDs in the DB jump 21 → 45; 22–44 were deleted. The URL was a stale link.)

## Fix

Make `projectionGraph` and `projectionState` **nullable**: a missing projection returns `null` (`RecordNotFound` → `Ok(None)`; real DB errors still propagate). The frontend already guards `!projection` and optional-chains graph/state, so a deleted projection now shows "Projection not found" with no console error.

Also removed two 0-byte stray `layercake.db` files (`frontend/`, `layercake-core/frontend/`) left from running the server in the wrong cwd. Left the non-empty DBs (`layercake-001.db`, `layercake-old.db`, `layercake-core/layercake.db`) untouched — they contain real data.

## Testing
- Verified live: querying the deleted id 33 now returns `{ projection: null, projectionGraph: null, projectionState: null }` with no `errors`; a real id returns data.
- Added `test_missing_projection_is_graceful` (get → None, load_graph → RecordNotFound).
- `cargo test -p layercake-projections` ✓ (8 tests), full workspace builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)