### PR TITLE
fix(server): warn before creating a new DB; log absolute path

### DIFF
--- a/layercake-server/src/server/mod.rs
+++ b/layercake-server/src/server/mod.rs
@@ -26,6 +26,28 @@ pub async fn start_server(
     cors_origin: Option<&str>,
     open_browser: bool,
 ) -> Result<()> {
+    // Warn loudly before creating a brand-new database file, and always report
+    // the absolute location. Running `serve --database layercake.db` from the
+    // wrong directory otherwise silently creates a stray empty DB in the cwd
+    // (and migrations then populate it), which looks like "my data vanished".
+    if database_path != ":memory:" {
+        let path = std::path::Path::new(database_path);
+        let creating = !path.exists();
+        let absolute = std::path::absolute(path)
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|_| database_path.to_string());
+        if creating {
+            warn!(
+                "Database file '{}' does not exist; creating a new empty database at {}. \
+                 If you expected existing data, stop and re-run from the correct directory \
+                 or pass an absolute --database path.",
+                database_path, absolute
+            );
+        } else {
+            info!("Using database at {}", absolute);
+        }
+    }
+
     let database_url = get_database_url(Some(database_path));
     let db = establish_connection(&database_url).await?;
 


### PR DESCRIPTION
## Summary

Prevents the "stray empty database" confusion at its source. Running `layercake serve --database layercake.db` from the wrong directory silently created a new empty DB in that cwd (SQLite `mode=rwc`), which migrations then populated — indistinguishable from data loss (this is how the stray `frontend/layercake.db`, `layercake-core/layercake.db` files got created).

## Change

Before opening the DB, the server now:
- **Warns loudly** with the resolved **absolute** path when it is about to *create* a new database file: `Database file 'X' does not exist; creating a new empty database at /abs/path. If you expected existing data, stop and re-run from the correct directory or pass an absolute --database path.`
- **Logs the absolute path** (`INFO: Using database at /abs/path`) when opening an existing one.

First-run creation still works — the danger case is just no longer silent. Uses `std::path::absolute` (works on non-existent paths, unlike `canonicalize`). Complements the existence/read-only guard `doctor` got in review-003.

## Testing
- New relative path in a fresh dir → WARN fires with the absolute location; DB still created (first-run works).
- Existing `layercake.db` → `INFO: Using database at <abs>`, no warn.
- `cargo build -p layercake-server` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)