### PR TITLE
feat(update): fix asset selection + add linux-aarch64 release target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ jobs:
             runs-on: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
 
+          - os-name: linux-aarch64
+            runs-on: ubuntu-24.04
+            target: aarch64-unknown-linux-gnu
+
           - os-name: windows-x86_64
             runs-on: windows-latest
             target: x86_64-pc-windows-msvc

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,17 +1,32 @@
 # Changelog
 
-## Unreleased
+## v0.4.0 - 2026-07-16
+
+### CLI & self-update
+- `layercake update` installs the latest release for your platform: it resolves the correct archive by name (skipping `.sha256`/signature sidecars so it never mistakes a checksum file for the binary), verifies the checksum, and replaces the binary in place. Supports `--check`, `--force`, `--pre-release`, `--backup`/`--rollback`, and `--dry-run`.
+- Added a `linux-aarch64` release target (`layercake-<ver>-linux-aarch64.tar.gz`) alongside `linux-x86_64`, `macos-aarch64`, and `windows-x86_64`; the installer script and updater already resolve it automatically.
 - Added the JSON-first `layercake query` command (and shared GraphQL helpers) so datasets, plans, DAG nodes/edges, and export previews can be managed by CLI or automation using canonical `dataset:/plan:/plannode:` identifiers.
 - Added the `layercake repl` shell that keeps project/plan context, parses simple commands (`set`, `list nodes`, `create node`, `download export`, etc.), and prints structured JSON responses so interactive agents can operate without the browser.
-- Documented the removal of the chat/RAG/MCP surface (see `plans/20260122-de-feature.md`) so the README/AGENTS instructions now advertise only plan, graph, data, and export workflows.
-- Added stub migrations for the previously dropped chat/RAG tables (`m20251030_000008`/`000009`, `m20251103_000010`/`000011`, `m20251112_000022`) so database migration history still satisfies the applied versions list.
-- Ensured `dev.sh` propagates `LAYERCAKE_LOCAL_AUTH_BYPASS` when starting the backend so local plan edits remain authorized even after the environment sample was simplified.
-- Defaulted `LAYERCAKE_LOCAL_AUTH_BYPASS` to `true` for debug builds so standalone local invocations get the prior unrestricted access without needing to set the env var manually.
-- Extended the bypass to default to `true` for all builds/targets so local runs keep unrestricted access unless the environment variable explicitly disables it, avoiding “Actor is not authorized for write:project” errors when editing plans locally.
-- Ensured artefact previews/downloads use the editor’s `projectId`/`planId` context after node creation so preview controls work immediately without reloading the canvas (GraphArtefact nodes now fall back to plan-context IDs when their per-node data is still syncing).
-- Added copy-ID controls in the dataset table, plan cards, and DAG nodes so the canonical `dataset:`, `plan:`, and `plannode:` strings are visible and easily copied for agents to reference.
-- GraphQL Graph/GraphData now expose `graphDataId`/`legacyGraphId` plus `sourceType`; clients should prefer `graphDataId` for all mutations/queries and treat `legacyGraphId` only as a badge/regeneration hint during the single-schema migration.
-- Backend graph queries/validation run solely on `graph_data`; legacy fallbacks removed ahead of the legacy table drop migration (`m20251215_000001_drop_legacy_graph_tables.rs`).
+- `layercake doctor` resolves the database from a running server's `/health`, opens it read-only, refuses a missing/no-tables database with a clear message, and supports `--strict` for CI.
+- `layercake api info` verifies the server via `/health`, reports the server's absolute database path, and detects live ports; `layercake schema type <Name>` gained `--only-inputs`/`--only-mutations`.
+
+### Server & data model
+- Backend graph queries/validation run solely on `graph_data`; legacy graph tables were dropped (`m20251215_000001_drop_legacy_graph_tables.rs`). GraphQL Graph/GraphData expose `graphDataId`/`legacyGraphId` plus `sourceType`; prefer `graphDataId` for all mutations/queries.
+- The server warns loudly (with the resolved absolute path) before creating a new database file, so running from the wrong directory no longer silently creates a stray empty database.
+- Node execution timings carry an `ExecutionPhase` (Execute/Render), exposed as `NodeExecutionTiming.phase`.
+- Added `diffDatasets` (structural graph diff), `renamePlanDagNode`, `exportProject`, `previewStoryContext`, `pruneOrphanedGraphs`, `applyPalettePreset`, and palette-preset/WCAG-contrast queries.
+
+### Stories, sequences & rendering
+- Stories can source sequences from computed graphs via `enabledGraphIds`, with a computed-graph source picker in the UI.
+- Switching a sequence artefact's render target between Mermaid and PlantUML now keeps the output-path extension in sync, and the server validates `renderTarget`↔extension so mismatched outputs are rejected. Neutralised a `;` that broke the Mermaid sequence grammar.
+- Loading a deleted projection in the viewer now shows a clean "not found" state instead of a top-level GraphQL error (`projectionGraph`/`projectionState` return null for a missing projection).
+
+### Frontend
+- Upgraded Mermaid to v11 and migrated to Apollo Client 4.2 (typed `TypedDocumentNode` documents throughout). Removed unused dependencies (assistant-ui, top-level react-dnd, stale `@types`). Fixed a latent bug where graph node/edge `attributes` were silently dropped on add/update.
+
+### Removed features & auth
+- Removed the chat/RAG/MCP surface (see `plans/20260122-de-feature.md`); added stub migrations so migration history still satisfies the applied-versions list.
+- `LAYERCAKE_LOCAL_AUTH_BYPASS` defaults to `true` for local runs (unless explicitly disabled), avoiding "Actor is not authorized for write:project" errors when editing plans locally; `dev.sh` propagates it to the backend.
 
 ## v0.3.6 - 2025-11-26
 - Added full Story and Sequence authoring workflows (GraphQL, UI editor, artefact previews, export fixes) so workbench projects can narrate execution paths alongside graph artefacts.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ Layercake is an interactive platform for designing, executing, and reviewing gra
 
 - **Post-install:** ensure the chosen install directory is on `PATH` (the scripts remind you how) and verify by running `layercake --version`.
 
+- **Supported release platforms:** `linux-x86_64`, `linux-aarch64`, `macos-aarch64`, and `windows-x86_64`. Pre-built archives are published on the [releases page](https://github.com/michiel/layercake-tool/releases); other platforms can build from source (see [BUILD.md](BUILD.md)).
+
+- **Updating:** once installed, upgrade in place with the built-in updater — it downloads the latest release for your platform, verifies its checksum, and replaces the binary:
+  ```bash
+  layercake update            # check, confirm, then install the latest release
+  layercake update --check    # only report whether an update is available
+  layercake update --backup   # keep a backup of the current binary (roll back with --rollback)
+  ```
+
 ## Removed Features
 - The chat, RAG, and MCP surfaces have been pulled from this workspace so the product now focuses on the plan editor, graph tools, data acquisition, and exporter flows. See `plans/20260122-de-feature.md` for the implementation log and rationale behind the de-feature effort.
 

--- a/docs-tool/command/update.md
+++ b/docs-tool/command/update.md
@@ -1,0 +1,50 @@
+# layercake update
+
+Update the installed `layercake` binary to the latest published release. The
+updater reads GitHub release metadata from `michiel/layercake-tool`, downloads
+the archive for the current platform, verifies its `.sha256` checksum, and
+replaces the running binary in place.
+
+## Usage
+
+```bash
+layercake update              # check, confirm, then install the latest release
+layercake update --check      # only report whether an update is available
+layercake update --force      # reinstall even if already up to date
+layercake update --pre-release  # consider pre-release versions too
+layercake update --backup     # back up the current binary before replacing it
+layercake update --rollback   # restore the most recent backup
+layercake update --dry-run    # show what would happen without changing anything
+```
+
+## How it fits
+
+Plain `layercake update` is interactive: it reports the current and latest
+versions, and only downloads when a newer release exists (use `--force` to
+reinstall the same version). `--check` is automation-friendly — it just reports
+status and does not install.
+
+The updater resolves the correct asset for your platform by name
+(`layercake-<version>-<os>-<arch>.<ext>`), skipping checksum/signature sidecars,
+so it picks the archive rather than the `.sha256` file.
+
+## Supported platforms
+
+Pre-built release archives exist for:
+
+- `linux-x86_64`
+- `linux-aarch64`
+- `macos-aarch64`
+- `windows-x86_64`
+
+On other platforms, build from source (see `BUILD.md`) — the updater will report
+that no compatible asset was found.
+
+## Operational notes
+
+- Replacing the binary may require write permission to its install directory; on
+  Unix, run with `sudo` if the binary lives in a system path.
+- `--backup` keeps the previous binary so `--rollback` can restore it if a new
+  release misbehaves.
+- The download is checksum-verified when a `.sha256` sidecar is published
+  alongside the archive.

--- a/layercake-core/src/update/updater.rs
+++ b/layercake-core/src/update/updater.rs
@@ -7,6 +7,19 @@ use reqwest::Client;
 use std::path::PathBuf;
 use tokio::io::AsyncWriteExt;
 
+/// A checksum/signature companion, not an installable artefact.
+fn is_sidecar(name: &str) -> bool {
+    const SIDECAR_SUFFIXES: [&str; 4] = [".sha256", ".sha512", ".sig", ".asc"];
+    SIDECAR_SUFFIXES
+        .iter()
+        .any(|suffix| name.ends_with(suffix))
+}
+
+/// A downloadable release archive we know how to extract.
+fn is_release_archive(name: &str) -> bool {
+    name.ends_with(".tar.gz") || name.ends_with(".tgz") || name.ends_with(".zip")
+}
+
 /// Default updater implementation
 pub struct DefaultUpdater {
     version_manager: Box<dyn VersionManager + Send + Sync>,
@@ -49,12 +62,16 @@ impl DefaultUpdater {
             return Ok(asset);
         }
 
-        // Try partial matches
+        // Try partial matches, excluding checksum/signature sidecars — those
+        // also contain the os/arch but are not the archive we want to install
+        // (e.g. "layercake-v0.4.0-linux-x86_64.tar.gz.sha256").
         let candidates: Vec<_> = release
             .assets
             .iter()
             .filter(|asset| {
-                asset.name.contains(&platform.os) && asset.name.contains(&platform.arch)
+                asset.name.contains(&platform.os)
+                    && asset.name.contains(&platform.arch)
+                    && !is_sidecar(&asset.name)
             })
             .collect();
 
@@ -65,14 +82,18 @@ impl DefaultUpdater {
             ))),
             1 => Ok(candidates[0]),
             _ => {
-                // Multiple candidates, try to find the best match
-                for asset in &candidates {
-                    if asset.name.ends_with(&platform.extension) {
-                        return Ok(asset);
-                    }
-                }
-                // If no exact extension match, return the first candidate
-                Ok(candidates[0])
+                // Multiple candidates: prefer a real release archive.
+                candidates
+                    .iter()
+                    .find(|asset| is_release_archive(&asset.name))
+                    .copied()
+                    .or_else(|| candidates.first().copied())
+                    .ok_or_else(|| {
+                        UpdateError::VerificationError(format!(
+                            "No compatible asset found for platform {}-{}",
+                            platform.os, platform.arch
+                        ))
+                    })
             }
         }
     }
@@ -261,7 +282,10 @@ impl Updater for DefaultUpdater {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::update::{DefaultBinaryManager, DefaultPlatformDetector, GitHubVersionManager};
+    use crate::update::{
+        DefaultBinaryManager, DefaultPlatformDetector, GitHubVersionManager, ReleaseAsset,
+        ReleaseInfo,
+    };
 
     #[tokio::test]
     async fn test_updater_creation() {
@@ -275,5 +299,61 @@ mod tests {
 
         // Basic test that updater can be created
         assert!(!updater.temp_dir.as_os_str().is_empty());
+    }
+
+    #[test]
+    fn sidecar_and_archive_classification() {
+        assert!(is_sidecar("layercake-v0.4.0-linux-x86_64.tar.gz.sha256"));
+        assert!(!is_sidecar("layercake-v0.4.0-linux-x86_64.tar.gz"));
+        assert!(is_release_archive("layercake-v0.4.0-linux-x86_64.tar.gz"));
+        assert!(is_release_archive("layercake-v0.4.0-windows-x86_64.zip"));
+        assert!(!is_release_archive("layercake-v0.4.0-linux-x86_64.tar.gz.sha256"));
+    }
+
+    fn asset(name: &str) -> ReleaseAsset {
+        ReleaseAsset {
+            name: name.to_string(),
+            download_url: format!("https://example.invalid/{name}"),
+            size: 1,
+            content_type: None,
+        }
+    }
+
+    #[test]
+    fn find_asset_prefers_archive_over_sha256_sidecar() {
+        // Real v0.4.0 asset layout: archive + its .sha256 both match os/arch.
+        let release = ReleaseInfo {
+            tag_name: "v0.4.0".to_string(),
+            name: "v0.4.0".to_string(),
+            body: None,
+            prerelease: false,
+            published_at: None,
+            assets: vec![
+                asset("layercake-v0.4.0-linux-x86_64.tar.gz"),
+                asset("layercake-v0.4.0-linux-x86_64.tar.gz.sha256"),
+                asset("layercake-v0.4.0-linux-aarch64.tar.gz"),
+                asset("layercake-v0.4.0-linux-aarch64.tar.gz.sha256"),
+            ],
+        };
+        let updater = DefaultUpdater::new(
+            Box::new(GitHubVersionManager::new("michiel/layercake-tool".to_string())),
+            Box::new(DefaultPlatformDetector::new()),
+            Box::new(DefaultBinaryManager::new()),
+        );
+
+        for (arch, expected) in [
+            ("x86_64", "layercake-v0.4.0-linux-x86_64.tar.gz"),
+            ("aarch64", "layercake-v0.4.0-linux-aarch64.tar.gz"),
+        ] {
+            let platform = PlatformInfo {
+                os: "linux".to_string(),
+                arch: arch.to_string(),
+                extension: String::new(),
+            };
+            let picked = updater
+                .find_asset_for_platform(&release, &platform)
+                .expect("an archive must be selected");
+            assert_eq!(picked.name, expected, "arch {arch} must pick the archive, not the .sha256");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Hardens the existing `layercake update` self-updater, adds an arm64 Linux release target, and documents it — plus rolls `CHANGES.md` into a v0.4.0 entry.

> Note: `layercake update` **already existed** and works (real 1,200-line implementation in `layercake-core/src/update/`, targeting `michiel/layercake-tool` releases; `--check` correctly reports up-to-date against v0.4.0). This PR fixes a latent bug in it and extends platform coverage rather than adding the command from scratch.

## Changes

**Fix asset selection** — `find_asset_for_platform` could pick a `.sha256` sidecar as the install archive: for non-Windows platforms the extension tiebreaker was an empty string, and every filename `ends_with("")`, so a checksum file could win over the archive (it only worked on v0.4.0 by luck of GitHub's asset ordering). Now excludes checksum/signature sidecars (`.sha256`/`.sha512`/`.sig`/`.asc`) and prefers real archives (`.tar.gz`/`.tgz`/`.zip`). Added unit tests over the exact v0.4.0 asset layout (x86_64 + aarch64).

**linux-aarch64 release target** — added to `.github/workflows/release.yml`, producing `layercake-<ver>-linux-aarch64.tar.gz`. The updater's platform detection (`aarch64`) and `scripts/install.sh` (`aarch64|arm64`) already resolve this name, so no client changes were needed. Cross-compile is clean (sea-orm + reqwest both use rustls; sqlx bundles sqlite — no OpenSSL).

**Docs** — README install section now lists supported platforms (incl. `linux-aarch64`) and an "Updating" subsection; new `docs-tool/command/update.md` (embedded, reachable via `layercake doc command update`).

**CHANGES.md** — rolled the `Unreleased` section into a dated `v0.4.0` entry summarising the release (self-update, arm64, data-model cutover, stories/sequences, the mermaid/apollo frontend upgrades, projections fix, server DB guard).

## Testing
- `cargo test -p layercake-core update::` ✓ (8 tests incl. the 2 new asset-selection tests)
- `cargo build --workspace` ✓
- `release.yml` validates; targets: linux-x86_64, **linux-aarch64**, windows-x86_64, macos-aarch64
- `layercake doc command update` renders; `layercake update --check` → "Already up to date" against v0.4.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)